### PR TITLE
Enhance/compose paths

### DIFF
--- a/package.json
+++ b/package.json
@@ -49,7 +49,7 @@
       "git add"
     ],
     "*.(tsx|ts)": [
-      "tslint --fix",
+      "tslint --fix --project .",
       "prettier --write",
       "git add"
     ]

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
   "name": "restful-react",
   "description": "A declarative client from RESTful React Apps",
-  "version": "4.0.0-2",
+  "version": "4.0.0-3",
   "main": "dist/index.js",
   "license": "MIT",
   "files": [

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -22,7 +22,7 @@ const { Provider, Consumer: RestfulReactConsumer } = React.createContext<Restful
 });
 
 export default class RestfulReactProvider<T> extends React.Component<RestfulReactProviderProps<T>> {
-  render() {
+  public render() {
     const { children, ...value } = this.props;
     return <Provider value={value}>{children}</Provider>;
   }

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -105,12 +105,12 @@ class ContextlessGet<T> extends React.Component<GetComponentProps<T>, Readonly<G
     loading: false,
   };
 
-  public static getDerivedStateFromProps(props: Pick<GetComponentProps, "wait" | "lazy">) {
+  public static getDerivedStateFromProps(props: Pick<GetComponentProps, "lazy">) {
     return { loading: !props.lazy };
   }
 
   public static defaultProps = {
-    resolve: (noop: any) => noop,
+    resolve: (unresolvedData: any) => unresolvedData,
   };
 
   public componentDidMount() {

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -1,5 +1,5 @@
 import * as React from "react";
-import RestfulProvider, { RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
+import RestfulReactProvider, { RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
 
 /**
  * An enumeration of states that a fetchable
@@ -70,13 +70,13 @@ export interface MutateComponentState {
  * debugging.
  */
 class ContextlessMutate extends React.Component<MutateComponentProps, MutateComponentState> {
-  readonly state: Readonly<MutateComponentState> = {
+  public readonly state: Readonly<MutateComponentState> = {
     response: null,
     loading: false,
     error: "",
   };
 
-  mutate = async (body?: string | {}, mutateRequestOptions?: RequestInit) => {
+  public mutate = async (body?: string | {}, mutateRequestOptions?: RequestInit) => {
     const { base, path, verb: method, requestOptions: providerRequestOptions } = this.props;
     this.setState(() => ({ error: "", loading: true }));
 
@@ -103,7 +103,7 @@ class ContextlessMutate extends React.Component<MutateComponentProps, MutateComp
     return response;
   };
 
-  render() {
+  public render() {
     const { children, path, base } = this.props;
     const { error, loading, response } = this.state;
 
@@ -125,9 +125,9 @@ function Mutate(props: MutateComponentProps) {
   return (
     <RestfulReactConsumer>
       {contextProps => (
-        <RestfulProvider {...contextProps} base={`${contextProps.base}${props.path}`}>
+        <RestfulReactProvider {...contextProps} base={`${contextProps.base}${props.path}`}>
           <ContextlessMutate {...contextProps} {...props} />
-        </RestfulProvider>
+        </RestfulReactProvider>
       )}
     </RestfulReactConsumer>
   );

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -233,13 +233,11 @@ function Poll<T>(props: PollProps<T>) {
   return (
     <RestfulReactConsumer>
       {contextProps => (
-        <RestfulProvider {...contextProps} base={`${contextProps.base}${props.path}`}>
-          <ContextlessPoll
-            {...contextProps}
-            {...props}
-            requestOptions={{ ...contextProps.requestOptions, ...props.requestOptions }}
-          />
-        </RestfulProvider>
+        <ContextlessPoll
+          {...contextProps}
+          {...props}
+          requestOptions={{ ...contextProps.requestOptions, ...props.requestOptions }}
+        />
       )}
     </RestfulReactConsumer>
   );

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -46,7 +46,7 @@ interface Actions {
 /**
  * Props that can control the Poll component.
  */
-interface PollProps<T> {
+interface PollProps<T = {}> {
   /**
    * What path are we polling on?
    */
@@ -126,20 +126,26 @@ interface PollState<T> {
  * The <Poll /> component without context.
  */
 class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollState<T>>> {
-  private keepPolling = !this.props.lazy;
-
   public readonly state: Readonly<PollState<T>> = {
     data: null,
     loading: !this.props.lazy,
     lastResponse: null,
-    polling: this.keepPolling,
+    polling: false,
     finished: false,
   };
+
+  public static getDerivedStateFromProps(props: Pick<PollProps, "lazy">) {
+    return {
+      polling: !props.lazy,
+    };
+  }
 
   public static defaultProps = {
     interval: 1000,
     resolve: (data: any) => data,
   };
+
+  private keepPolling = !this.props.lazy;
 
   /**
    * This thing does the actual poll.

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -1,7 +1,6 @@
 import React from "react";
 import { RestfulReactConsumer } from "./Context";
-import { RestfulProvider } from ".";
-import { GetComponentState, Meta as GetComponentMeta, GetComponentProps } from "./Get";
+import { GetComponentProps, GetComponentState, Meta as GetComponentMeta } from "./Get";
 
 /**
  * Meta information returned from the poll.
@@ -128,7 +127,8 @@ interface PollState<T> {
  */
 class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollState<T>>> {
   private keepPolling = !this.props.lazy;
-  readonly state: Readonly<PollState<T>> = {
+
+  public readonly state: Readonly<PollState<T>> = {
     data: null,
     loading: !this.props.lazy,
     lastResponse: null,
@@ -136,7 +136,7 @@ class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollStat
     finished: false,
   };
 
-  static defaultProps = {
+  public static defaultProps = {
     interval: 1000,
     resolve: (data: any) => data,
   };
@@ -144,7 +144,7 @@ class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollStat
   /**
    * This thing does the actual poll.
    */
-  cycle = async () => {
+  public cycle = async () => {
     // Have we stopped?
     if (!this.keepPolling) {
       return; // stop.
@@ -172,22 +172,23 @@ class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollStat
       data: resolve ? resolve(responseBody) : responseBody,
     }));
 
-    await new Promise(resolve => setTimeout(resolve, interval)); // Wait for interval to pass.
+    // Wait for interval to pass.
+    await new Promise(resolvePromise => setTimeout(resolvePromise, interval));
     this.cycle(); // Do it all again!
   };
 
-  start = async () => {
+  public start = async () => {
     this.keepPolling = true;
     this.setState(() => ({ polling: true })); // let everyone know we're done here.}
     this.cycle();
   };
 
-  stop = async () => {
+  public stop = async () => {
     this.keepPolling = false;
     this.setState(() => ({ polling: false, finished: true })); // let everyone know we're done here.}
   };
 
-  componentDidMount() {
+  public componentDidMount() {
     const { path, lazy } = this.props;
 
     if (!path) {
@@ -196,14 +197,16 @@ class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollStat
       );
     }
 
-    !lazy && this.start();
+    if (!lazy) {
+      this.start();
+    }
   }
 
-  componentWillUnmount() {
+  public componentWillUnmount() {
     this.stop();
   }
 
-  render() {
+  public render() {
     const { lastResponse: response, data, polling, loading, error, finished } = this.state;
     const { children, base, path } = this.props;
 

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -5,4 +5,5 @@ export { default as Poll } from "./Poll";
 export { default as Mutate } from "./Mutate";
 
 export { Get };
+
 export default Get;

--- a/tslint.json
+++ b/tslint.json
@@ -1,1 +1,23 @@
-{}
+{
+  "extends": ["tslint:recommended", "tslint-config-prettier", "tslint-plugin-blank-line"],
+  "rules": {
+    "blank-line": true,
+    "one-variable-per-declaration": false,
+    "semicolon": false,
+    "quotemark": "double",
+    "variable-name": ["allow-pascal-case"],
+    "indent": false,
+    "import-name": false,
+    "object-literal-sort-keys": false,
+    "interface-name": false,
+    "no-console": [true, "log", "error"],
+    "no-unused-expression": true,
+    "no-implicit-dependencies": [true, "dev"],
+    "no-unused-variable": [true, { "check-parameters": true }],
+    "no-duplicate-imports": true,
+    "completed-docs": false,
+    "import-spacing": true,
+    "match-default-export-name": true,
+    "member-ordering": false
+  }
+}


### PR DESCRIPTION
# Why

Currently, when using `Poll`, every `Get` inside it has its path appended to whatever `Poll`'s path was. _But why?_ Typically, a user would want to poll a specific endpoint and _not_ have it affect subsequent `GET` requests. This PR solves this case.

It also removes the possibility of nesting `Poll` paths, which generally is a bad practice. _Why would anyone nest Polls?_
