### PR TITLE
Fix error handling and resource deletion

### DIFF
--- a/package.json
+++ b/package.json
@@ -61,7 +61,7 @@
     "jest": "^23.1.0",
     "lint-staged": "^7.2.0",
     "prettier": "^1.13.5",
-    "rollup": "^0.61.2",
+    "rollup": "^0.63.5",
     "rollup-plugin-typescript2": "^0.16.1",
     "ts-jest": "^22.4.6",
     "tslint": "^5.10.0",

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -33,7 +33,7 @@ interface States<T> {
   /**
    * Is there an error? What is it?
    */
-  error?: PollState<T>["error"];
+  error: PollState<T>["error"];
 }
 
 /**
@@ -129,7 +129,7 @@ interface PollState<T> {
   /**
    * Do we currently have an error?
    */
-  error?: GetComponentState<T>["error"];
+  error: GetComponentState<T>["error"];
   /**
    * Index of the last polled response.
    */
@@ -146,6 +146,7 @@ class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollStat
     lastResponse: null,
     polling: !this.props.lazy,
     finished: false,
+    error: null,
   };
 
   public static defaultProps = {
@@ -207,7 +208,7 @@ class ContextlessPoll<T> extends React.Component<PollProps<T>, Readonly<PollStat
       response.headers.get("content-type") === "application/json" ? await response.json() : await response.text();
 
     if (!this.isResponseOk(response)) {
-      const error = `${response.status} ${response.statusText}`;
+      const error = { message: `${response.status} ${response.statusText}`, data: response };
       this.setState({ loading: false, lastResponse: response, data: responseBody, error });
       throw new Error(`Failed to Poll: ${error}`);
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -3436,9 +3436,9 @@ rollup-pluginutils@2.3.0:
     estree-walker "^0.5.2"
     micromatch "^2.3.11"
 
-rollup@^0.61.2:
-  version "0.61.2"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.61.2.tgz#30a953736964683a5b8ea952b137a393d84e6302"
+rollup@^0.63.5:
+  version "0.63.5"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-0.63.5.tgz#5543eecac9a1b83b7e1be598b5be84c9c0a089db"
   dependencies:
     "@types/estree" "0.0.39"
     "@types/node" "*"


### PR DESCRIPTION
# Why
Currently, Restful React has two limitations for our use cases in Contiamo:

- When an error occurs, some errors contain responses in JSON. These responses are now stored in the `error` prop passed to children. Errors are forced into a format detailed below:

```ts
interface Error<S> {
  data: S
  message: string
}
```

- The `DELETE` verb formerly exposed its API to require a `body`, when really, Restful DELETE requests typically live on `/resource/:resourceId`. Now, the DELETE function takes an ID as an argument instead of an entire object.

<!-- Why did you make this PR? What problem does it solve? -->
