### PR TITLE
Unit tests - Get component

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -167,6 +167,50 @@ describe("Get", () => {
     });
   });
 
+  describe("with base", () => {
+    it("should override the base url", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://not-here.fake">
+          <Get path="" base="https://my-awesome-api.fake">
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+
+    it("should override the base url and compose with the path", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/plop")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://not-here.fake">
+          <Get path="/plop" base="https://my-awesome-api.fake">
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+  });
+
   describe("with custom request options", () => {
     it("should add a custom header", async () => {
       nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -102,6 +102,30 @@ describe("Get", () => {
     });
   });
 
+  describe("with error", () => {
+    it("should set the `error` object properly", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(401, { message: "You shall not pass!" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][0]).toEqual(null);
+      expect(children.mock.calls[1][1].error).toEqual({
+        data: { message: "You shall not pass!" },
+        message: "Failed to fetch: 401 Unauthorized",
+      });
+    });
+  });
+
   describe("with custom resolver", () => {
     it("should transform data", async () => {
       nock("https://my-awesome-api.fake")

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -184,6 +184,7 @@ describe("Get", () => {
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
 
       // refetch
@@ -192,6 +193,13 @@ describe("Get", () => {
         .reply(200, { id: 2 });
       children.mock.calls[1][2].refetch();
       await wait(() => expect(children.mock.calls.length).toBe(4));
+
+      // transition state
+      expect(children.mock.calls[2][1].loading).toEqual(true);
+      expect(children.mock.calls[2][0]).toEqual({ id: 1 });
+
+      // after refetch state
+      expect(children.mock.calls[3][1].loading).toEqual(false);
       expect(children.mock.calls[3][0]).toEqual({ id: 2 });
     });
   });

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -166,4 +166,33 @@ describe("Get", () => {
       expect(children.mock.calls[0][0]).toBe(null);
     });
   });
+
+  describe("actions", () => {
+    it("should refetch", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // initial fetch
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+
+      // refetch
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { id: 2 });
+      children.mock.calls[1][2].refetch();
+      await wait(() => expect(children.mock.calls.length).toBe(4));
+      expect(children.mock.calls[3][0]).toEqual({ id: 2 });
+    });
+  });
 });

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -167,6 +167,29 @@ describe("Get", () => {
     });
   });
 
+  describe("with custom request options", () => {
+    it("should add a custom header", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" requestOptions={{ headers: { foo: "bar" } }}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+  });
+
   describe("actions", () => {
     it("should refetch", async () => {
       nock("https://my-awesome-api.fake")

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -29,7 +29,7 @@ export interface States<S> {
  */
 export interface Actions<T> {
   /** Refetches the same path */
-  refetch: () => Promise<T>;
+  refetch: () => Promise<T | null>;
 }
 
 /**
@@ -176,7 +176,7 @@ class ContextlessGet<T> extends React.Component<GetComponentProps<T>, Readonly<G
         loading: false,
         error: { message: `Failed to fetch: ${response.status} ${response.statusText}`, data },
       });
-      throw response;
+      return null;
     }
 
     this.setState({ loading: false, data: resolve!(data) });

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -7,29 +7,29 @@ import RestfulReactProvider, { RestfulReactConsumer, RestfulReactProviderProps }
  */
 export type ResolveFunction<T> = (data: any) => T;
 
-export interface GetDataError<S> {
+export interface GetDataError<TError> {
   message: string;
-  data: S;
+  data: TError;
 }
 
 /**
  * An enumeration of states that a fetchable
  * view could possibly have.
  */
-export interface States<S> {
+export interface States<TData, TError> {
   /** Is our view currently loading? */
   loading: boolean;
   /** Do we have an error in the view? */
-  error?: GetComponentState<S>["error"];
+  error?: GetComponentState<TData, TError>["error"];
 }
 
 /**
  * An interface of actions that can be performed
  * within Get
  */
-export interface Actions<T> {
+export interface Actions<TData> {
   /** Refetches the same path */
-  refetch: () => Promise<T | null>;
+  refetch: () => Promise<TData | null>;
 }
 
 /**
@@ -46,7 +46,7 @@ export interface Meta {
 /**
  * Props for the <Get /> component.
  */
-export interface GetComponentProps<T = {}, S = {}> {
+export interface GetComponentProps<TData, TError> {
   /**
    * The path at which to request data,
    * typically composed by parent Gets or the RestfulProvider.
@@ -59,14 +59,14 @@ export interface GetComponentProps<T = {}, S = {}> {
    * @param data - data returned from the request.
    * @param actions - a key/value map of HTTP verbs, aliasing destroy to DELETE.
    */
-  children: (data: T | null, states: States<S>, actions: Actions<T>, meta: Meta) => React.ReactNode;
+  children: (data: TData | null, states: States<TData, TError>, actions: Actions<TData>, meta: Meta) => React.ReactNode;
   /** Options passed into the fetch call. */
   requestOptions?: RestfulReactProviderProps["requestOptions"];
   /**
    * A function to resolve data return from the backend, most typically
    * used when the backend response needs to be adapted in some way.
    */
-  resolve?: ResolveFunction<T>;
+  resolve?: ResolveFunction<TData>;
   /**
    * Should we wait until we have data before rendering?
    * This is useful in cases where data is available too quickly
@@ -90,7 +90,7 @@ export interface GetComponentProps<T = {}, S = {}> {
  * are implementation details and should be
  * hidden from any consumers.
  */
-export interface GetComponentState<T, S = {}> {
+export interface GetComponentState<T, S> {
   data: T | null;
   response: Response | null;
   error: GetDataError<S> | null;
@@ -102,15 +102,18 @@ export interface GetComponentState<T, S = {}> {
  * is a named class because it is useful in
  * debugging.
  */
-class ContextlessGet<T> extends React.Component<GetComponentProps<T>, Readonly<GetComponentState<T>>> {
-  public readonly state: Readonly<GetComponentState<T>> = {
+class ContextlessGet<TData, TError> extends React.Component<
+  GetComponentProps<TData, TError>,
+  Readonly<GetComponentState<TData, TError>>
+> {
+  public readonly state: Readonly<GetComponentState<TData, TError>> = {
     data: null, // Means we don't _yet_ have data.
     response: null,
     loading: !this.props.lazy,
     error: null,
   };
 
-  public static defaultProps: Partial<GetComponentProps<{}>> = {
+  public static defaultProps = {
     resolve: (unresolvedData: any) => unresolvedData,
   };
 
@@ -120,7 +123,7 @@ class ContextlessGet<T> extends React.Component<GetComponentProps<T>, Readonly<G
     }
   }
 
-  public componentDidUpdate(prevProps: GetComponentProps<T>) {
+  public componentDidUpdate(prevProps: GetComponentProps<TData, TError>) {
     // If the path or base prop changes, refetch!
     const { path, base } = this.props;
     if (prevProps.path !== path || prevProps.base !== base) {
@@ -168,7 +171,7 @@ class ContextlessGet<T> extends React.Component<GetComponentProps<T>, Readonly<G
     const request = new Request(`${base}${requestPath || path || ""}`, this.getRequestOptions(thisRequestOptions));
     const response = await fetch(request);
 
-    const data: T =
+    const data =
       response.headers.get("content-type") === "application/json" ? await response.json() : await response.text();
 
     if (!response.ok) {
@@ -205,7 +208,7 @@ class ContextlessGet<T> extends React.Component<GetComponentProps<T>, Readonly<G
  * in order to provide new `base` props that contain
  * a segment of the path, creating composable URLs.
  */
-function Get<T>(props: GetComponentProps<T>) {
+function Get<TData = {}, TError = {}>(props: GetComponentProps<TData, TError>) {
   return (
     <RestfulReactConsumer>
       {contextProps => (


### PR DESCRIPTION
# Why

The following of #17 

### Note

I've have removed the throwing inside `fetch`, it was a bit weird and really hard to test. In fact I wondering how it works in real world?

BTW, I think that in this context, it's not really practicle and I prefer to deal with a simple `error` object.

I think that the original idea was to do this:
```jsx
<RestfulProvider base="https://my-awesome-api.fake">
  <Get path="">
    {(_, {}, { refetch }) => (
      <Button
        onClick={() => {
          refetch()
            .then()
            .catch();
        }}
      />
    )}
  </Get>
</RestfulProvider>;
```

But it's more natural to deal with error in the first level like this:

```jsx
<RestfulProvider base="https://my-awesome-api.fake">
  <Get path="">
    {(_, { error }, { refetch }) =>
      error ? (
        "error!"
      ) : (
        <Button
          onClick={() => {
            refetch();
          }}
        />
      )
    }
  </Get>
</RestfulProvider>;
```

And, because we use `this.fetch` for the `refresh` and the "initial fetch" it's really hard to catch an error for this first fetch :wink: