### PR TITLE
Fix Delete action without id

### DIFF
--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -1,0 +1,80 @@
+import "isomorphic-fetch";
+import "jest-dom/extend-expect";
+import nock from "nock";
+import React from "react";
+import { cleanup, render, wait } from "react-testing-library";
+
+import { Mutate, RestfulProvider } from "./index";
+
+afterEach(() => {
+  cleanup();
+  nock.cleanAll();
+});
+
+describe("Mutate", () => {
+  describe("DELETE", () => {
+    it("should call the correct url with a specific id", async () => {
+      nock("https://my-awesome-api.fake")
+        .delete("/plop")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Mutate verb="DELETE" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // delete action
+      children.mock.calls[0][0]("plop");
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after delete state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+
+    it("should call the correct url without id", async () => {
+      nock("https://my-awesome-api.fake")
+        .delete("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Mutate verb="DELETE" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // delete action
+      children.mock.calls[0][0](); // no id specified here
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after delete state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+  });
+});

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -111,7 +111,7 @@ class ContextlessMutate<TData, TError> extends React.Component<
     const { base, path, verb, requestOptions: providerRequestOptions } = this.props;
     this.setState(() => ({ error: null, loading: true }));
 
-    const requestPath = verb === "DELETE" ? `${base}${path || ""}/${body}` : `${base}${path || ""}`;
+    const requestPath = verb === "DELETE" ? `${base}${path || ""}${body ? "/" + body : ""}` : `${base}${path || ""}`;
     const request = new Request(requestPath, {
       method: verb,
       body: typeof body === "object" ? JSON.stringify(body) : body,


### PR DESCRIPTION
# Why

Actually, if no id is provided for a DELETE operation, we call `${base}${path}/undefined`, so we broken some implementations.


