### PR TITLE
Refactor props names and exports

### DIFF
--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -20,7 +20,7 @@ export interface States<TData, TError> {
   /** Is our view currently loading? */
   loading: boolean;
   /** Do we have an error in the view? */
-  error?: GetComponentState<TData, TError>["error"];
+  error?: GetState<TData, TError>["error"];
 }
 
 /**
@@ -46,7 +46,7 @@ export interface Meta {
 /**
  * Props for the <Get /> component.
  */
-export interface GetComponentProps<TData, TError> {
+export interface GetProps<TData, TError> {
   /**
    * The path at which to request data,
    * typically composed by parent Gets or the RestfulProvider.
@@ -90,10 +90,10 @@ export interface GetComponentProps<TData, TError> {
  * are implementation details and should be
  * hidden from any consumers.
  */
-export interface GetComponentState<T, S> {
-  data: T | null;
+export interface GetState<TData, TError> {
+  data: TData | null;
   response: Response | null;
-  error: GetDataError<S> | null;
+  error: GetDataError<TError> | null;
   loading: boolean;
 }
 
@@ -103,10 +103,10 @@ export interface GetComponentState<T, S> {
  * debugging.
  */
 class ContextlessGet<TData, TError> extends React.Component<
-  GetComponentProps<TData, TError>,
-  Readonly<GetComponentState<TData, TError>>
+  GetProps<TData, TError>,
+  Readonly<GetState<TData, TError>>
 > {
-  public readonly state: Readonly<GetComponentState<TData, TError>> = {
+  public readonly state: Readonly<GetState<TData, TError>> = {
     data: null, // Means we don't _yet_ have data.
     response: null,
     loading: !this.props.lazy,
@@ -123,7 +123,7 @@ class ContextlessGet<TData, TError> extends React.Component<
     }
   }
 
-  public componentDidUpdate(prevProps: GetComponentProps<TData, TError>) {
+  public componentDidUpdate(prevProps: GetProps<TData, TError>) {
     // If the path or base prop changes, refetch!
     const { path, base } = this.props;
     if (prevProps.path !== path || prevProps.base !== base) {
@@ -208,7 +208,7 @@ class ContextlessGet<TData, TError> extends React.Component<
  * in order to provide new `base` props that contain
  * a segment of the path, creating composable URLs.
  */
-function Get<TData = {}, TError = {}>(props: GetComponentProps<TData, TError>) {
+function Get<TData = {}, TError = {}>(props: GetProps<TData, TError>) {
   return (
     <RestfulReactConsumer>
       {contextProps => (

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -1,6 +1,6 @@
 import * as React from "react";
 import RestfulReactProvider, { RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
-import { GetComponentState } from "./Get";
+import { GetState } from "./Get";
 
 /**
  * An enumeration of states that a fetchable
@@ -10,7 +10,7 @@ export interface States<TData, TError> {
   /** Is our view currently loading? */
   loading: boolean;
   /** Do we have an error in the view? */
-  error?: GetComponentState<TData, TError>["error"];
+  error?: GetState<TData, TError>["error"];
 }
 
 /**
@@ -27,7 +27,7 @@ export interface Meta {
 /**
  * Props for the <Mutate /> component.
  */
-export interface MutateComponentCommonProps {
+export interface MutateCommonProps {
   /**
    * The path at which to request data,
    * typically composed by parents or the RestfulProvider.
@@ -47,7 +47,7 @@ export interface MutateComponentCommonProps {
   requestOptions?: RestfulReactProviderProps["requestOptions"];
 }
 
-export interface MutateComponentWithDelete<TData, TError> extends MutateComponentCommonProps {
+export interface MutateWithDeleteProps<TData, TError> extends MutateCommonProps {
   verb: "DELETE";
   /**
    * A function that recieves a mutation function, along with
@@ -62,7 +62,7 @@ export interface MutateComponentWithDelete<TData, TError> extends MutateComponen
   ) => React.ReactNode;
 }
 
-export interface MutateComponentWithOtherVerb<TData, TError> extends MutateComponentCommonProps {
+export interface MutateWithOtherVerbProps<TData, TError> extends MutateCommonProps {
   verb: "POST" | "PUT" | "PATCH";
   /**
    * A function that recieves a mutation function, along with
@@ -77,18 +77,16 @@ export interface MutateComponentWithOtherVerb<TData, TError> extends MutateCompo
   ) => React.ReactNode;
 }
 
-export type MutateComponentProps<TData, TError> =
-  | MutateComponentWithDelete<TData, TError>
-  | MutateComponentWithOtherVerb<TData, TError>;
+export type MutateProps<TData, TError> = MutateWithDeleteProps<TData, TError> | MutateWithOtherVerbProps<TData, TError>;
 
 /**
  * State for the <Mutate /> component. These
  * are implementation details and should be
  * hidden from any consumers.
  */
-export interface MutateComponentState<TData, TError> {
+export interface MutateState<TData, TError> {
   response: Response | null;
-  error: GetComponentState<TData, TError>["error"];
+  error: GetState<TData, TError>["error"];
   loading: boolean;
 }
 
@@ -97,11 +95,8 @@ export interface MutateComponentState<TData, TError> {
  * is a named class because it is useful in
  * debugging.
  */
-class ContextlessMutate<TData, TError> extends React.Component<
-  MutateComponentProps<TData, TError>,
-  MutateComponentState<TData, TError>
-> {
-  public readonly state: Readonly<MutateComponentState<TData, TError>> = {
+class ContextlessMutate<TData, TError> extends React.Component<MutateProps<TData, TError>, MutateState<TData, TError>> {
+  public readonly state: Readonly<MutateState<TData, TError>> = {
     response: null,
     loading: false,
     error: null,
@@ -159,7 +154,7 @@ class ContextlessMutate<TData, TError> extends React.Component<
  * in order to provide new `base` props that contain
  * a segment of the path, creating composable URLs.
  */
-function Mutate<TError = {}, TData = {}>(props: MutateComponentProps<TData, TError>) {
+function Mutate<TError = {}, TData = {}>(props: MutateProps<TData, TError>) {
   return (
     <RestfulReactConsumer>
       {contextProps => (

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -2,7 +2,7 @@ import React from "react";
 import equal from "react-fast-compare";
 
 import { RestfulReactConsumer } from "./Context";
-import { GetComponentProps, GetComponentState, Meta as GetComponentMeta } from "./Get";
+import { GetProps, GetState, Meta as GetComponentMeta } from "./Get";
 
 /**
  * Meta information returned from the poll.
@@ -48,11 +48,11 @@ interface Actions {
 /**
  * Props that can control the Poll component.
  */
-interface PollProps<TData, TError> {
+export interface PollProps<TData, TError> {
   /**
    * What path are we polling on?
    */
-  path: GetComponentProps<TData, TError>["path"];
+  path: GetProps<TData, TError>["path"];
   /**
    * A function that gets polled data, the current
    * states, meta information, and various actions
@@ -85,19 +85,19 @@ interface PollProps<TData, TError> {
    * Are we going to wait to start the poll?
    * Use this with { start, stop } actions.
    */
-  lazy?: GetComponentProps<TData, TError>["lazy"];
+  lazy?: GetProps<TData, TError>["lazy"];
   /**
    * Should the data be transformed in any way?
    */
-  resolve?: GetComponentProps<TData, TError>["resolve"];
+  resolve?: GetProps<TData, TError>["resolve"];
   /**
    * We can request foreign URLs with this prop.
    */
-  base?: GetComponentProps<TData, TError>["base"];
+  base?: GetProps<TData, TError>["base"];
   /**
    * Any options to be passed to this request.
    */
-  requestOptions?: GetComponentProps<TData, TError>["requestOptions"];
+  requestOptions?: GetProps<TData, TError>["requestOptions"];
 }
 
 /**
@@ -105,7 +105,7 @@ interface PollProps<TData, TError> {
  * implementation details not necessarily exposed to
  * consumers.
  */
-interface PollState<TData, TError> {
+export interface PollState<TData, TError> {
   /**
    * Are we currently polling?
    */
@@ -121,15 +121,15 @@ interface PollState<TData, TError> {
   /**
    * What data are we holding in here?
    */
-  data: GetComponentState<TData, TError>["data"];
+  data: GetState<TData, TError>["data"];
   /**
    * Are we loading?
    */
-  loading: GetComponentState<TData, TError>["loading"];
+  loading: GetState<TData, TError>["loading"];
   /**
    * Do we currently have an error?
    */
-  error: GetComponentState<TData, TError>["error"];
+  error: GetState<TData, TError>["error"];
   /**
    * Index of the last polled response.
    */

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,9 +1,9 @@
-import Get from "./Get";
+import Get, { GetProps } from "./Get";
 
 export { default as RestfulProvider } from "./Context";
-export { default as Poll } from "./Poll";
-export { default as Mutate } from "./Mutate";
+export { default as Poll, PollProps } from "./Poll";
+export { default as Mutate, MutateProps } from "./Mutate";
 
-export { Get };
+export { Get, GetProps };
 
 export default Get;


### PR DESCRIPTION
# Why

We have two differents patterns: `PollProps` vs `GetComponentProps` and we don't export any props for now.

If we want to extend any component, it can be useful to have the props accessible. It's the goal of this PR :wink:
