### PR TITLE
Factor out handling of response content type handler

### DIFF
--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -171,7 +171,6 @@ class ContextlessGet<TData, TError> extends React.Component<
 
     const request = new Request(`${base}${requestPath || path || ""}`, this.getRequestOptions(thisRequestOptions));
     const response = await fetch(request);
-
     const data = await processResponse(response);
 
     if (!response.ok) {

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -1,5 +1,6 @@
 import * as React from "react";
 import RestfulReactProvider, { RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
+import { processResponse } from "./util/processResponse";
 
 /**
  * A function that resolves returned data from
@@ -171,8 +172,7 @@ class ContextlessGet<TData, TError> extends React.Component<
     const request = new Request(`${base}${requestPath || path || ""}`, this.getRequestOptions(thisRequestOptions));
     const response = await fetch(request);
 
-    const data =
-      response.headers.get("content-type") === "application/json" ? await response.json() : await response.text();
+    const data = await processResponse(response);
 
     if (!response.ok) {
       this.setState({
@@ -208,7 +208,7 @@ class ContextlessGet<TData, TError> extends React.Component<
  * in order to provide new `base` props that contain
  * a segment of the path, creating composable URLs.
  */
-function Get<TData = {}, TError = {}>(props: GetProps<TData, TError>) {
+function Get<TData = any, TError = any>(props: GetProps<TData, TError>) {
   return (
     <RestfulReactConsumer>
       {contextProps => (

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -154,7 +154,7 @@ class ContextlessMutate<TData, TError> extends React.Component<MutateProps<TData
  * in order to provide new `base` props that contain
  * a segment of the path, creating composable URLs.
  */
-function Mutate<TError = {}, TData = {}>(props: MutateProps<TData, TError>) {
+function Mutate<TError = any, TData = any>(props: MutateProps<TData, TError>) {
   return (
     <RestfulReactConsumer>
       {contextProps => (

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -208,7 +208,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
     });
     const response = await fetch(request);
 
-    const responseBody = processResponse(response);
+    const responseBody = await processResponse(response);
 
     if (!this.isResponseOk(response)) {
       const error = { message: `${response.status} ${response.statusText}`, data: responseBody };

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -206,21 +206,21 @@ class ContextlessPoll<TData, TError> extends React.Component<
         ...requestOptions.headers,
       },
     });
-    const response = await fetch(request);
 
-    const responseBody = await processResponse(response);
+    const response = await fetch(request);
+    const data = await processResponse(response);
 
     if (!this.isResponseOk(response)) {
-      const error = { message: `${response.status} ${response.statusText}`, data: responseBody };
-      this.setState({ loading: false, lastResponse: response, data: responseBody, error });
+      const error = { message: `${response.status} ${response.statusText}`, data };
+      this.setState({ loading: false, lastResponse: response, data, error });
       throw new Error(`Failed to Poll: ${error}`);
     }
 
-    if (this.isModified(response, responseBody)) {
+    if (this.isModified(response, data)) {
       this.setState(() => ({
         loading: false,
         lastResponse: response,
-        data: resolve ? resolve(responseBody) : responseBody,
+        data: resolve ? resolve(data) : data,
         lastPollIndex: response.headers.get("x-polling-index") || undefined,
       }));
     }

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -3,6 +3,7 @@ import equal from "react-fast-compare";
 
 import { RestfulReactConsumer } from "./Context";
 import { GetProps, GetState, Meta as GetComponentMeta } from "./Get";
+import { processResponse } from "./util/processResponse";
 
 /**
  * Meta information returned from the poll.
@@ -207,8 +208,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
     });
     const response = await fetch(request);
 
-    const responseBody =
-      response.headers.get("content-type") === "application/json" ? await response.json() : await response.text();
+    const responseBody = processResponse(response);
 
     if (!this.isResponseOk(response)) {
       const error = { message: `${response.status} ${response.statusText}`, data: responseBody };
@@ -284,7 +284,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
   }
 }
 
-function Poll<TData = {}, TError = {}>(props: PollProps<TData, TError>) {
+function Poll<TData = any, TError = any>(props: PollProps<TData, TError>) {
   // Compose Contexts to allow for URL nesting
   return (
     <RestfulReactConsumer>

--- a/src/util/processResponse.ts
+++ b/src/util/processResponse.ts
@@ -1,0 +1,7 @@
+export const processResponse = (response: Response) => {
+  if ((response.headers.get("content-type") || "").includes("application/json")) {
+    return response.json();
+  } else {
+    return response.text();
+  }
+};


### PR DESCRIPTION
# Why
Responses with `Content-Type: application/json; charset: utf-8` are resolved as plain-text responses and cannot be processed accordingly in Restful React.

<!-- Why did you make this PR? What problem does it solve? -->
