### PR TITLE
Add seconds to prefer header

### DIFF
--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -201,7 +201,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
       ...requestOptions,
 
       headers: {
-        Prefer: `wait=${wait};${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
+        Prefer: `wait=${wait}s;${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
 
         ...requestOptions.headers,
       },


### PR DESCRIPTION
# Why
Because it's the spec.

<!-- Why did you make this PR? What problem does it solve? -->
