### PR TITLE
Improve the error management for Poll

### DIFF
--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -16,16 +16,16 @@ describe("Poll", () => {
     it("should call the url set in provider", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;"
-        }
+          prefer: "wait=60s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;index=1"
-        }
+          prefer: "wait=60s;index=1",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "2" });
@@ -36,7 +36,7 @@ describe("Poll", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Poll path="">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -45,16 +45,16 @@ describe("Poll", () => {
     it("should compose the url with the base", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;"
-        }
+          prefer: "wait=60s;",
+        },
       })
         .get("/plop")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;index=1"
-        }
+          prefer: "wait=60s;index=1",
+        },
       })
         .get("/plop")
         .reply(200, { data: "hello" }, { "x-polling-index": "2" });
@@ -65,7 +65,7 @@ describe("Poll", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Poll path="/plop">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -74,16 +74,16 @@ describe("Poll", () => {
     it("should set loading to `true` on mount", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;"
-        }
+          prefer: "wait=60s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;index=1"
-        }
+          prefer: "wait=60s;index=1",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "2" });
@@ -94,7 +94,7 @@ describe("Poll", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Poll path="">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -104,16 +104,16 @@ describe("Poll", () => {
     it("should set loading to `false` on data", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;"
-        }
+          prefer: "wait=60s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=60s;index=1"
-        }
+          prefer: "wait=60s;index=1",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "2" });
@@ -124,7 +124,7 @@ describe("Poll", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Poll path="">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -134,16 +134,16 @@ describe("Poll", () => {
     it("should send data on data", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;"
-        }
+          prefer: "wait=0s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;index=1"
-        }
+          prefer: "wait=0s;index=1",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "2" });
@@ -156,7 +156,7 @@ describe("Poll", () => {
           <Poll path="" wait={0}>
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -166,16 +166,16 @@ describe("Poll", () => {
     it("should update data if the response change", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;"
-        }
+          prefer: "wait=0s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;index=1"
-        }
+          prefer: "wait=0s;index=1",
+        },
       })
         .get("/")
         .reply(200, { data: "hello you" }, { "x-polling-index": "2" });
@@ -188,7 +188,7 @@ describe("Poll", () => {
           <Poll path="" wait={0}>
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(3));
@@ -208,14 +208,14 @@ describe("Poll", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Poll path="">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
       expect(children.mock.calls[1][0]).toEqual(null);
       expect(children.mock.calls[1][1].error).toEqual({
         data: { message: "You shall not pass!" },
-        message: "Failed to poll: 401 Unauthorized"
+        message: "Failed to poll: 401 Unauthorized",
       });
     });
 
@@ -223,7 +223,7 @@ describe("Poll", () => {
       nock("https://my-awesome-api.fake")
         .get("/")
         .reply(200, "<html>404 - this is not a json!</html>", {
-          "content-type": "application/json"
+          "content-type": "application/json",
         });
 
       const children = jest.fn();
@@ -232,7 +232,7 @@ describe("Poll", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Poll path="">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -241,7 +241,7 @@ describe("Poll", () => {
         data:
           "invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
         message:
-          "Failed to poll: 200 OK - invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0"
+          "Failed to poll: 200 OK - invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
       });
     });
 
@@ -249,13 +249,13 @@ describe("Poll", () => {
       nock("https://my-awesome-api.fake")
         .get("/")
         .reply(504, "<html>504 Gateway Time-out</html>", {
-          "content-type": "text/html"
+          "content-type": "text/html",
         });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;"
-        }
+          prefer: "wait=0s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
@@ -268,7 +268,7 @@ describe("Poll", () => {
           <Poll path="" wait={0}>
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(3));
@@ -277,7 +277,7 @@ describe("Poll", () => {
       expect(children.mock.calls[1][0]).toEqual(null);
       expect(children.mock.calls[1][1].error).toEqual({
         data: "<html>504 Gateway Time-out</html>",
-        message: "Failed to poll: 504 Gateway Timeout"
+        message: "Failed to poll: 504 Gateway Timeout",
       });
 
       // second res (success)
@@ -296,12 +296,9 @@ describe("Poll", () => {
       children.mockReturnValue(<div />);
 
       render(
-        <RestfulProvider
-          base="https://my-awesome-api.fake"
-          resolve={data => ({ ...data, foo: "bar" })}
-        >
+        <RestfulProvider base="https://my-awesome-api.fake" resolve={data => ({ ...data, foo: "bar" })}>
           <Poll path="">{children}</Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -321,7 +318,7 @@ describe("Poll", () => {
           <Poll path="" resolve={data => ({ ...data, foo: "bar" })}>
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -331,16 +328,16 @@ describe("Poll", () => {
     it("should be able to consolidate data", async () => {
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;"
-        }
+          prefer: "wait=0s;",
+        },
       })
         .get("/")
         .reply(200, { data: "hello" }, { "x-polling-index": "1" });
 
       nock("https://my-awesome-api.fake", {
         reqheaders: {
-          prefer: "wait=0s;index=1"
-        }
+          prefer: "wait=0s;index=1",
+        },
       })
         .get("/")
         .reply(200, { data: " you" }, { "x-polling-index": "2" });
@@ -354,12 +351,12 @@ describe("Poll", () => {
             path=""
             wait={0}
             resolve={(data, prevData) => ({
-              data: (prevData || { data: "" }).data + data.data
+              data: (prevData || { data: "" }).data + data.data,
             })}
           >
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(3));
@@ -377,7 +374,7 @@ describe("Poll", () => {
           <Poll path="" lazy>
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(1));
@@ -400,7 +397,7 @@ describe("Poll", () => {
           <Poll path="" base="https://my-awesome-api.fake">
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -421,7 +418,7 @@ describe("Poll", () => {
           <Poll path="/plop" base="https://my-awesome-api.fake">
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
@@ -444,7 +441,7 @@ describe("Poll", () => {
           <Poll path="" requestOptions={{ headers: { foo: "bar" } }}>
             {children}
           </Poll>
-        </RestfulProvider>
+        </RestfulProvider>,
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -59,7 +59,12 @@ export interface PollProps<TData, TError> {
    * states, meta information, and various actions
    * that can be executed at the poll-level.
    */
-  children: (data: TData | null, states: States<TData, TError>, actions: Actions, meta: Meta) => React.ReactNode;
+  children: (
+    data: TData | null,
+    states: States<TData, TError>,
+    actions: Actions,
+    meta: Meta
+  ) => React.ReactNode;
   /**
    * How long do we wait between repeating a request?
    * Value in milliseconds.
@@ -150,13 +155,13 @@ class ContextlessPoll<TData, TError> extends React.Component<
     lastResponse: null,
     polling: !this.props.lazy,
     finished: false,
-    error: null,
+    error: null
   };
 
   public static defaultProps = {
     interval: 1000,
     wait: 60,
-    resolve: (data: any) => data,
+    resolve: (data: any) => data
   };
 
   private keepPolling = !this.props.lazy;
@@ -178,10 +183,13 @@ class ContextlessPoll<TData, TError> extends React.Component<
   };
 
   private getRequestOptions = () =>
-    typeof this.props.requestOptions === "function" ? this.props.requestOptions() : this.props.requestOptions || {};
+    typeof this.props.requestOptions === "function"
+      ? this.props.requestOptions()
+      : this.props.requestOptions || {};
 
   // 304 is not a OK status code but is green in Chrome 🤦🏾‍♂️
-  private isResponseOk = (response: Response) => response.ok || response.status === 304;
+  private isResponseOk = (response: Response) =>
+    response.ok || response.status === 304;
 
   /**
    * This thing does the actual poll.
@@ -193,7 +201,10 @@ class ContextlessPoll<TData, TError> extends React.Component<
     }
 
     // Should we stop?
-    if (this.props.until && this.props.until(this.state.data, this.state.lastResponse)) {
+    if (
+      this.props.until &&
+      this.props.until(this.state.data, this.state.lastResponse)
+    ) {
       await this.stop(); // stop.
       return;
     }
@@ -206,9 +217,11 @@ class ContextlessPoll<TData, TError> extends React.Component<
     const request = new Request(`${base}${path}`, {
       ...requestOptions,
       headers: {
-        Prefer: `wait=${wait}s;${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
-        ...requestOptions.headers,
-      },
+        Prefer: `wait=${wait}s;${
+          lastPollIndex ? `index=${lastPollIndex}` : ""
+        }`,
+        ...requestOptions.headers
+      }
     });
 
     try {
@@ -222,19 +235,19 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
       if (!this.isResponseOk(response) || responseError) {
         const error = {
-          message: `${response.status} ${response.statusText}${responseError ? " - " + data : ""}`,
-          data,
+          message: `Failed to poll: ${response.status} ${response.statusText}${
+            responseError ? " - " + data : ""
+          }`,
+          data
         };
-        this.setState({ loading: false, lastResponse: response, data, error });
-        throw new Error(`Failed to Poll: ${error}`);
-      }
-
-      if (this.isModified(response, data)) {
+        this.setState({ loading: false, lastResponse: response, error });
+      } else if (this.isModified(response, data)) {
         this.setState(prevState => ({
           loading: false,
           lastResponse: response,
           data: resolve ? resolve(data, prevState.data) : data,
-          lastPollIndex: response.headers.get("x-polling-index") || undefined,
+          error: null,
+          lastPollIndex: response.headers.get("x-polling-index") || undefined
         }));
       }
 
@@ -264,7 +277,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
     if (path === undefined) {
       throw new Error(
-        `[restful-react]: You're trying to poll something without a path. Please specify a "path" prop on your Poll component.`,
+        `[restful-react]: You're trying to poll something without a path. Please specify a "path" prop on your Poll component.`
       );
     }
 
@@ -282,24 +295,31 @@ class ContextlessPoll<TData, TError> extends React.Component<
   }
 
   public render() {
-    const { lastResponse: response, data, polling, loading, error, finished } = this.state;
+    const {
+      lastResponse: response,
+      data,
+      polling,
+      loading,
+      error,
+      finished
+    } = this.state;
     const { children, base, path } = this.props;
 
     const meta: Meta = {
       response,
-      absolutePath: `${base}${path}`,
+      absolutePath: `${base}${path}`
     };
 
     const states: States<TData, TError> = {
       polling,
       loading,
       error,
-      finished,
+      finished
     };
 
     const actions: Actions = {
       stop: this.stop,
-      start: this.start,
+      start: this.start
     };
 
     return children(data, states, actions, meta);
@@ -316,7 +336,7 @@ function Poll<TData = any, TError = any>(props: PollProps<TData, TError>) {
           {...props}
           requestOptions={{
             ...contextProps.requestOptions,
-            ...props.requestOptions,
+            ...props.requestOptions
           }}
         />
       )}

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -59,12 +59,7 @@ export interface PollProps<TData, TError> {
    * states, meta information, and various actions
    * that can be executed at the poll-level.
    */
-  children: (
-    data: TData | null,
-    states: States<TData, TError>,
-    actions: Actions,
-    meta: Meta
-  ) => React.ReactNode;
+  children: (data: TData | null, states: States<TData, TError>, actions: Actions, meta: Meta) => React.ReactNode;
   /**
    * How long do we wait between repeating a request?
    * Value in milliseconds.
@@ -155,13 +150,13 @@ class ContextlessPoll<TData, TError> extends React.Component<
     lastResponse: null,
     polling: !this.props.lazy,
     finished: false,
-    error: null
+    error: null,
   };
 
   public static defaultProps = {
     interval: 1000,
     wait: 60,
-    resolve: (data: any) => data
+    resolve: (data: any) => data,
   };
 
   private keepPolling = !this.props.lazy;
@@ -183,13 +178,10 @@ class ContextlessPoll<TData, TError> extends React.Component<
   };
 
   private getRequestOptions = () =>
-    typeof this.props.requestOptions === "function"
-      ? this.props.requestOptions()
-      : this.props.requestOptions || {};
+    typeof this.props.requestOptions === "function" ? this.props.requestOptions() : this.props.requestOptions || {};
 
   // 304 is not a OK status code but is green in Chrome 🤦🏾‍♂️
-  private isResponseOk = (response: Response) =>
-    response.ok || response.status === 304;
+  private isResponseOk = (response: Response) => response.ok || response.status === 304;
 
   /**
    * This thing does the actual poll.
@@ -201,10 +193,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
     }
 
     // Should we stop?
-    if (
-      this.props.until &&
-      this.props.until(this.state.data, this.state.lastResponse)
-    ) {
+    if (this.props.until && this.props.until(this.state.data, this.state.lastResponse)) {
       await this.stop(); // stop.
       return;
     }
@@ -217,11 +206,9 @@ class ContextlessPoll<TData, TError> extends React.Component<
     const request = new Request(`${base}${path}`, {
       ...requestOptions,
       headers: {
-        Prefer: `wait=${wait}s;${
-          lastPollIndex ? `index=${lastPollIndex}` : ""
-        }`,
-        ...requestOptions.headers
-      }
+        Prefer: `wait=${wait}s;${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
+        ...requestOptions.headers,
+      },
     });
 
     try {
@@ -235,10 +222,8 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
       if (!this.isResponseOk(response) || responseError) {
         const error = {
-          message: `Failed to poll: ${response.status} ${response.statusText}${
-            responseError ? " - " + data : ""
-          }`,
-          data
+          message: `Failed to poll: ${response.status} ${response.statusText}${responseError ? " - " + data : ""}`,
+          data,
         };
         this.setState({ loading: false, lastResponse: response, error });
       } else if (this.isModified(response, data)) {
@@ -247,7 +232,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
           lastResponse: response,
           data: resolve ? resolve(data, prevState.data) : data,
           error: null,
-          lastPollIndex: response.headers.get("x-polling-index") || undefined
+          lastPollIndex: response.headers.get("x-polling-index") || undefined,
         }));
       }
 
@@ -277,7 +262,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
     if (path === undefined) {
       throw new Error(
-        `[restful-react]: You're trying to poll something without a path. Please specify a "path" prop on your Poll component.`
+        `[restful-react]: You're trying to poll something without a path. Please specify a "path" prop on your Poll component.`,
       );
     }
 
@@ -295,31 +280,24 @@ class ContextlessPoll<TData, TError> extends React.Component<
   }
 
   public render() {
-    const {
-      lastResponse: response,
-      data,
-      polling,
-      loading,
-      error,
-      finished
-    } = this.state;
+    const { lastResponse: response, data, polling, loading, error, finished } = this.state;
     const { children, base, path } = this.props;
 
     const meta: Meta = {
       response,
-      absolutePath: `${base}${path}`
+      absolutePath: `${base}${path}`,
     };
 
     const states: States<TData, TError> = {
       polling,
       loading,
       error,
-      finished
+      finished,
     };
 
     const actions: Actions = {
       stop: this.stop,
-      start: this.start
+      start: this.start,
     };
 
     return children(data, states, actions, meta);
@@ -336,7 +314,7 @@ function Poll<TData = any, TError = any>(props: PollProps<TData, TError>) {
           {...props}
           requestOptions={{
             ...contextProps.requestOptions,
-            ...props.requestOptions
+            ...props.requestOptions,
           }}
         />
       )}


### PR DESCRIPTION
# Why

Because as a noob I've commited a `.skip` on this part 😆 and also because we have a lot of foggy spots on this part.

The idea is to be as close as possible of `Get` regarding the comportement and also continue polling after an error (so the `until` props is really useful)
