### PR TITLE
resolve urls instead concat url strings

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,8 @@
   "dependencies": {
     "lodash": "^4.17.10",
     "react": "^16.4.1",
-    "react-fast-compare": "^2.0.1"
+    "react-fast-compare": "^2.0.1",
+    "url": "^0.11.0"
   },
   "peerDependencies": {
     "react": "^16.4.1"

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -146,9 +146,9 @@ describe("Get", () => {
       expect(children.mock.calls[1][0]).toEqual(null);
       expect(children.mock.calls[1][1].error).toEqual({
         data:
-          "invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
+          "invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
         message:
-          "Failed to fetch: 200 OK - invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
+          "Failed to fetch: 200 OK - invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
       });
     });
 

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -31,6 +31,23 @@ describe("Get", () => {
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
 
+    it("should deal with trailing slashs", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200);
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake/">
+          <Get path="/">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+    });
+
     it("should compose the url with the base", async () => {
       nock("https://my-awesome-api.fake")
         .get("/plop")

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -90,7 +90,7 @@ export interface GetProps<TData, TError> {
    * to fetch from an entirely different URL.
    *
    */
-  base: string;
+  base?: string;
   /**
    * How long do we wait between subsequent requests?
    * Uses [lodash's debounce](https://lodash.com/docs/4.17.10#debounce) under the hood.
@@ -201,7 +201,7 @@ class ContextlessGet<TData, TError> extends React.Component<
     }
 
     const request = new Request(
-      url.resolve(base, requestPath || path || ""),
+      url.resolve(base!, requestPath || path || ""),
       this.getRequestOptions(thisRequestOptions),
     );
     const response = await fetch(request);
@@ -241,7 +241,7 @@ class ContextlessGet<TData, TError> extends React.Component<
       data,
       { loading, error },
       { refetch: this.fetch },
-      { response, absolutePath: url.resolve(base, path) },
+      { response, absolutePath: url.resolve(base!, path) },
     );
   }
 }

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -1,4 +1,5 @@
 import * as React from "react";
+import url from "url";
 import RestfulReactProvider, { InjectedProps, RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
 import { GetState } from "./Get";
 import { processResponse } from "./util/processResponse";
@@ -33,7 +34,7 @@ export interface MutateCommonProps {
    * The path at which to request data,
    * typically composed by parents or the RestfulProvider.
    */
-  path?: string;
+  path: string;
   /**
    * What HTTP verb are we using?
    */
@@ -43,7 +44,7 @@ export interface MutateCommonProps {
    * to fetch from an entirely different URL.
    *
    */
-  base?: string;
+  base: string;
   /** Options passed into the fetch call. */
   requestOptions?: RestfulReactProviderProps["requestOptions"];
   /**
@@ -110,11 +111,19 @@ class ContextlessMutate<TData, TError> extends React.Component<
     error: null,
   };
 
+  public static defaultProps = {
+    base: "",
+    path: "",
+  };
+
   public mutate = async (body?: string | {}, mutateRequestOptions?: RequestInit) => {
     const { base, path, verb, requestOptions: providerRequestOptions } = this.props;
     this.setState(() => ({ error: null, loading: true }));
 
-    const requestPath = verb === "DELETE" ? `${base}${path || ""}${body ? "/" + body : ""}` : `${base}${path || ""}`;
+    const requestPath =
+      verb === "DELETE" && typeof body === "string"
+        ? url.resolve(base, url.resolve(path, body))
+        : url.resolve(base, path);
     const request = new Request(requestPath, {
       method: verb,
       body: typeof body === "object" ? JSON.stringify(body) : body,

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -44,7 +44,7 @@ export interface MutateCommonProps {
    * to fetch from an entirely different URL.
    *
    */
-  base: string;
+  base?: string;
   /** Options passed into the fetch call. */
   requestOptions?: RestfulReactProviderProps["requestOptions"];
   /**
@@ -122,8 +122,8 @@ class ContextlessMutate<TData, TError> extends React.Component<
 
     const requestPath =
       verb === "DELETE" && typeof body === "string"
-        ? url.resolve(base, url.resolve(path, body))
-        : url.resolve(base, path);
+        ? url.resolve(base!, url.resolve(path, body))
+        : url.resolve(base!, path);
     const request = new Request(requestPath, {
       method: verb,
       body: typeof body === "object" ? JSON.stringify(body) : body,

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -239,9 +239,9 @@ describe("Poll", () => {
       expect(children.mock.calls[1][0]).toEqual(null);
       expect(children.mock.calls[1][1].error).toEqual({
         data:
-          "invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
+          "invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
         message:
-          "Failed to poll: 200 OK - invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
+          "Failed to poll: 200 OK - invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
       });
     });
 

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -95,7 +95,7 @@ export interface PollProps<TData, TError> {
   /**
    * We can request foreign URLs with this prop.
    */
-  base: GetProps<TData, TError>["base"];
+  base?: GetProps<TData, TError>["base"];
   /**
    * Any options to be passed to this request.
    */
@@ -209,7 +209,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
     const { lastPollIndex } = this.state;
     const requestOptions = this.getRequestOptions();
 
-    const request = new Request(url.resolve(base, path), {
+    const request = new Request(url.resolve(base!, path), {
       ...requestOptions,
       headers: {
         Prefer: `wait=${wait}s;${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
@@ -295,7 +295,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
     const meta: Meta = {
       response,
-      absolutePath: url.resolve(base, path),
+      absolutePath: url.resolve(base!, path),
     };
 
     const states: States<TData, TError> = {

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -1,5 +1,6 @@
 import React from "react";
 import equal from "react-fast-compare";
+import url from "url";
 
 import { InjectedProps, RestfulReactConsumer } from "./Context";
 import { GetProps, GetState, Meta as GetComponentMeta } from "./Get";
@@ -94,7 +95,7 @@ export interface PollProps<TData, TError> {
   /**
    * We can request foreign URLs with this prop.
    */
-  base?: GetProps<TData, TError>["base"];
+  base: GetProps<TData, TError>["base"];
   /**
    * Any options to be passed to this request.
    */
@@ -160,6 +161,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
   public static defaultProps = {
     interval: 1000,
     wait: 60,
+    base: "",
     resolve: (data: any) => data,
   };
 
@@ -207,7 +209,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
     const { lastPollIndex } = this.state;
     const requestOptions = this.getRequestOptions();
 
-    const request = new Request(`${base}${path}`, {
+    const request = new Request(url.resolve(base, path), {
       ...requestOptions,
       headers: {
         Prefer: `wait=${wait}s;${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
@@ -293,7 +295,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
     const meta: Meta = {
       response,
-      absolutePath: `${base}${path}`,
+      absolutePath: url.resolve(base, path),
     };
 
     const states: States<TData, TError> = {


### PR DESCRIPTION
# Why

URLs in methods are resolving unexpected, due to the urls are simply concatenating. This PR use `url.resolve` to enable users to use absolute and relative paths expectedly.