### PR TITLE
Remove engine in package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,9 +7,6 @@
   "files": [
     "lib"
   ],
-  "engines": {
-    "vscode": "^1.22.0"
-  },
   "keywords": [
     "rest",
     "restful",


### PR DESCRIPTION
# Why

<!-- Why did you make this PR? What problem does it solve? -->

I don't think the `engine` setting is right in `package.json` 

It cause built fail in now

```
> warning @canner/restful-react@5.1.1: The engine "vscode" appears to be invalid.
> info fsevents@1.2.4: The platform "linux" is incompatible with this module.
> info "fsevents@1.2.4" is an optional dependency and failed compatibility check. Excluding it from installation.
> warning restful-react@5.2.0: The engine "vscode" appears to be invalid.
> [4/5] Linking dependencies..
```

FYI: https://docs.npmjs.com/files/package.json#engines