### PR TITLE
Fix the error case on Get with `wait` property

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -274,6 +274,88 @@ describe("Get", () => {
     });
   });
 
+  describe("with wait", () => {
+    it("should render nothing if until we have data", async () => {
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" wait>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(0));
+    });
+
+    it("should render if we have data", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" wait>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toBe(false);
+      expect(children.mock.calls[0][0]).toEqual({ hello: "world" });
+    });
+    it("should render if we have data", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" wait>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toBe(false);
+      expect(children.mock.calls[0][0]).toEqual({ hello: "world" });
+    });
+
+    it("should render if we have an error", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(401, "Go away!");
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" wait>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toBe(false);
+      expect(children.mock.calls[0][1].error).toEqual({
+        data: "Go away!",
+        message: "Failed to fetch: 401 Unauthorized",
+      });
+    });
+  });
+
   describe("with base", () => {
     it("should override the base url", async () => {
       nock("https://my-awesome-api.fake")

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -228,7 +228,7 @@ class ContextlessGet<TData, TError> extends React.Component<
     const { children, wait, path, base } = this.props;
     const { data, error, loading, response } = this.state;
 
-    if (wait && data === null) {
+    if (wait && data === null && !error) {
       return <></>; // Show nothing until we have data.
     }
 


### PR DESCRIPTION
# Why

Actually we don't have the error if we use `<Get wait />`. This PR fix this specific case.
