### PR TITLE
compose urls for relative paths cases

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -6,6 +6,11 @@ export interface RestfulReactProviderProps<T = any> {
   /** The backend URL where the RESTful resources live. */
   base: string;
   /**
+   * The path that gets accumulated from each level of nesting
+   * taking the absolute and relative nature of each path into consideration
+   */
+  parentPath?: string;
+  /**
    * A function to resolve data return from the backend, most typically
    * used when the backend response needs to be adapted in some way.
    */
@@ -26,6 +31,7 @@ export interface RestfulReactProviderProps<T = any> {
 
 const { Provider, Consumer: RestfulReactConsumer } = React.createContext<Required<RestfulReactProviderProps>>({
   base: "",
+  parentPath: "",
   resolve: (data: any) => data,
   requestOptions: {},
   onError: noop,
@@ -44,6 +50,7 @@ export default class RestfulReactProvider<T> extends React.Component<RestfulReac
           onError: noop,
           resolve: (data: any) => data,
           requestOptions: {},
+          parentPath: "",
           ...value,
         }}
       >

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -239,9 +239,9 @@ describe("Poll", () => {
       expect(children.mock.calls[1][0]).toEqual(null);
       expect(children.mock.calls[1][1].error).toEqual({
         data:
-          "invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
+          "invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
         message:
-          "Failed to poll: 200 OK - invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
+          "Failed to poll: 200 OK - invalid json response body at https://my-awesome-api.fake reason: Unexpected token < in JSON at position 0",
       });
     });
 
@@ -494,6 +494,44 @@ describe("Poll", () => {
           <Poll path="/plop" base="https://my-awesome-api.fake">
             {children}
           </Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+    
+    it("should compose urls with base subpath", async () => {
+      nock("https://my-awesome-api.fake/MY_SUBROUTE")
+        .get("/absolute")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake/MY_SUBROUTE">
+          <Poll path="/absolute">{children}</Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+
+    it("should compose urls properly when base has a trailing slash", async () => {
+      nock("https://my-awesome-api.fake/MY_SUBROUTE")
+        .get("/absolute")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake/MY_SUBROUTE/">
+          <Poll path="/absolute">{children}</Poll>
         </RestfulProvider>,
       );
 

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -1,9 +1,9 @@
 import React from "react";
 import equal from "react-fast-compare";
-import url from "url";
 
 import { InjectedProps, RestfulReactConsumer } from "./Context";
 import { GetProps, GetState, Meta as GetComponentMeta } from "./Get";
+import { composeUrl } from "./util/composeUrl";
 import { processResponse } from "./util/processResponse";
 
 /**
@@ -214,7 +214,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
     const { lastPollIndex } = this.state;
     const requestOptions = this.getRequestOptions();
 
-    const request = new Request(url.resolve(base!, path), {
+    const request = new Request(composeUrl(base!, "", path), {
       ...requestOptions,
       headers: {
         Prefer: `wait=${wait}s;${lastPollIndex ? `index=${lastPollIndex}` : ""}`,
@@ -301,7 +301,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
 
     const meta: Meta = {
       response,
-      absolutePath: url.resolve(base!, path),
+      absolutePath: composeUrl(base!, "", path),
     };
 
     const states: States<TData, TError> = {

--- a/src/util/composeUrl.test.ts
+++ b/src/util/composeUrl.test.ts
@@ -1,0 +1,93 @@
+import { composePath, composePathWithBody, composeUrl } from "./composeUrl";
+
+describe("compose paths and urls", () => {
+  it("should handle empty parentPath with absolute path", () => {
+    const parentPath = "";
+    const path = "/absolute";
+    expect(composePath(parentPath, path)).toBe("/absolute");
+
+    const base = "https://my-awesome-api.fake";
+    expect(composeUrl(base, parentPath, path)).toBe("https://my-awesome-api.fake/absolute");
+
+    const baseWithSubpath = "https://my-awesome-api.fake/MY_SUBROUTE";
+    expect(composeUrl(baseWithSubpath, parentPath, path)).toBe("https://my-awesome-api.fake/MY_SUBROUTE/absolute");
+  });
+
+  it("should handle empty parentPath with relative path", () => {
+    const parentPath = "";
+    const path = "relative";
+    expect(composePath(parentPath, path)).toBe("/relative");
+
+    const base = "https://my-awesome-api.fake";
+    expect(composeUrl(base, parentPath, path)).toBe("https://my-awesome-api.fake/relative");
+
+    const baseWithSubpath = "https://my-awesome-api.fake/MY_SUBROUTE";
+    expect(composeUrl(baseWithSubpath, parentPath, path)).toBe("https://my-awesome-api.fake/MY_SUBROUTE/relative");
+  });
+
+  it("should ignore empty string from path", () => {
+    const parentPath = "/someBasePath";
+    const path = "";
+    expect(composePath(parentPath, path)).toBe("/someBasePath");
+
+    const base = "https://my-awesome-api.fake";
+    expect(composeUrl(base, parentPath, path)).toBe("https://my-awesome-api.fake/someBasePath");
+
+    const baseWithSubpath = "https://my-awesome-api.fake/MY_SUBROUTE";
+    expect(composeUrl(baseWithSubpath, parentPath, path)).toBe("https://my-awesome-api.fake/MY_SUBROUTE/someBasePath");
+  });
+
+  it("should ignore lone forward slash from path", () => {
+    const parentPath = "/someBasePath";
+    const path = "/";
+    expect(composePath(parentPath, path)).toBe("/someBasePath");
+
+    const base = "https://my-awesome-api.fake";
+    expect(composeUrl(base, parentPath, path)).toBe("https://my-awesome-api.fake/someBasePath");
+
+    const baseWithSubpath = "https://my-awesome-api.fake/MY_SUBROUTE";
+    expect(composeUrl(baseWithSubpath, parentPath, path)).toBe("https://my-awesome-api.fake/MY_SUBROUTE/someBasePath");
+  });
+
+  it("should not include parentPath value when path is absolute", () => {
+    const parentPath = "/someBasePath";
+    const path = "/absolute";
+    expect(composePath(parentPath, path)).toBe("/absolute");
+
+    const base = "https://my-awesome-api.fake";
+    expect(composeUrl(base, parentPath, path)).toBe("https://my-awesome-api.fake/absolute");
+
+    const baseWithSubpath = "https://my-awesome-api.fake/MY_SUBROUTE";
+    expect(composeUrl(baseWithSubpath, parentPath, path)).toBe("https://my-awesome-api.fake/MY_SUBROUTE/absolute");
+  });
+
+  it("should include parentPath value when path is relative", () => {
+    const parentPath = "/someBasePath";
+    const path = "relative";
+    expect(composePath(parentPath, path)).toBe("/someBasePath/relative");
+
+    const base = "https://my-awesome-api.fake";
+    expect(composeUrl(base, parentPath, path)).toBe("https://my-awesome-api.fake/someBasePath/relative");
+
+    const baseWithSubpath = "https://my-awesome-api.fake/MY_SUBROUTE";
+    expect(composeUrl(baseWithSubpath, parentPath, path)).toBe(
+      "https://my-awesome-api.fake/MY_SUBROUTE/someBasePath/relative",
+    );
+  });
+});
+
+describe("compose path with body", () => {
+  it("should compose body with absolute path", () => {
+    const path = "/absolute";
+    const body = "?somebody";
+
+    expect(composePathWithBody(path, body)).toBe("/absolute?somebody");
+  });
+
+  it("should compose body with relative path", () => {
+    const path = "relative";
+    const body = "?somebody";
+
+    expect(composePathWithBody(path, body)).toBe("relative?somebody");
+  });
+});

--- a/src/util/composeUrl.ts
+++ b/src/util/composeUrl.ts
@@ -1,0 +1,27 @@
+import url from "url";
+
+export const composeUrl = (base: string, parentPath: string, path: string): string => {
+  const composedPath = composePath(parentPath, path);
+  /* If the base contains a trailing slash, it will be trimmed during composition */
+  return base!.endsWith("/") ? `${base!.slice(0, -1)}${composedPath}` : `${base}${composedPath}`;
+};
+
+/**
+ * If the path starts with slash, it is considered as absolute url.
+ * If not, it is considered as relative url.
+ * For example,
+ * parentPath = "/someBasePath" and path = "/absolute" resolves to "/absolute"
+ * whereas,
+ * parentPath = "/someBasePath" and path = "relative" resolves to "/someBasePath/relative"
+ */
+export const composePath = (parentPath: string, path: string): string => {
+  if (path.startsWith("/") && path.length > 1) {
+    return url.resolve(parentPath, path);
+  } else if (path !== "" && path !== "/") {
+    return `${parentPath}/${path}`;
+  } else {
+    return parentPath;
+  }
+};
+
+export const composePathWithBody = (path: string, body: string): string => url.resolve(path, body);


### PR DESCRIPTION
# Why

To compose relative urls explicitly using no forward slash in path value. Refer #29 for more background.

# Outcome

If the path starts with forward slash, it is considered as absolute url. If not, it is considered as relative url.
For example,
```
base = "/people" and path = "/absolute" resolves to "/absolute"
```
whereas,
```
base = "/people" and path = "relative" resolves to "/people/relative"
```

# Note

In the nested cases, the immediate parent's url becomes base for composition.
For example, 
```
 <RestfulProvider base="https://my-awesome-api.fake/MY_SUBROUTE">
  <Get path="/absolute-1">
    {() => (
      <Get path="relative-1">
        {() => (
          <Get path="/absolute-2">
            {() => <Get path="relative-2">{() => <Get path="relative-3">{children}</Get>}</Get>}
          </Get>
        )}
      </Get>
    )}
  </Get>
</RestfulProvider>
```
emits 
`"https://my-awesome-api.fake/MY_SUBROUTE/absolute-1"`
`"https://my-awesome-api.fake/MY_SUBROUTE/absolute-1/relative-1"`
`"https://my-awesome-api.fake/MY_SUBROUTE/absolute-2"`
`"https://my-awesome-api.fake/MY_SUBROUTE/absolute-2/relative-2"`
`"https://my-awesome-api.fake/MY_SUBROUTE/absolute-2/relative-2/relative-3"`
