### PR TITLE
**Feature:** Add support for validators that are promise-based or throw errors

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -93,6 +93,9 @@ typings/
 public
 lib
 
+# Cache for parcel serverl in example
+.cache
+
 # Files managed by operational-scripts
 tslint.json
 tsconfig.json

--- a/example/README.md
+++ b/example/README.md
@@ -1,0 +1,1 @@
+This is a simple live demo of `restul-react` components primarily used to test features. Run it with `npm run example`.

--- a/example/index.html
+++ b/example/index.html
@@ -1,0 +1,2 @@
+<div id="app"></div>
+<script src="index.tsx"></script>

--- a/example/index.tsx
+++ b/example/index.tsx
@@ -1,0 +1,32 @@
+import * as React from "react";
+import { render } from "react-dom";
+
+import { Get, RestfulProvider } from "../src";
+
+const wait = timeout =>
+  new Promise((resolve, reject) => {
+    setTimeout(() => {
+      resolve();
+    }, timeout);
+  });
+
+const App: React.SFC<{}> = props => (
+  <RestfulProvider base="https://dog.ceo">
+    <Get path="/api/breeds/list/all" resolve={res => wait(1500).then(() => Promise.resolve(Object.keys(res.message)))}>
+      {(breeds, { loading, error }) => {
+        if (loading) {
+          return "loading..";
+        }
+        if (error) {
+          return <code>{JSON.stringify(error)}</code>;
+        }
+        if (breeds) {
+          return <ul>{breeds.map((breed, breedIndex) => <li key={breedIndex}>{breed}</li>)}</ul>;
+        }
+        return null;
+      }}
+    </Get>
+  </RestfulProvider>
+);
+
+render(<App />, document.querySelector("#app"));

--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
   },
   "scripts": {
     "start": "operational-scripts start",
+    "example": "parcel example/index.html",
     "test": "operational-scripts test",
     "build": "operational-scripts build --for npm",
     "preversion": "npm run build",
@@ -54,6 +55,7 @@
     "jest-dom": "^1.12.0",
     "lint-staged": "^7.2.0",
     "nock": "^10.0.0",
+    "parcel": "^1.10.3",
     "prettier": "^1.13.5",
     "react-dom": "^16.4.2",
     "react-testing-library": "^5.0.0",
@@ -64,7 +66,7 @@
     "typescript": "^3.0.3"
   },
   "dependencies": {
-    "lodash": "^4.17.10",
+    "lodash": "^4.17.11",
     "react": "^16.4.1",
     "react-fast-compare": "^2.0.1",
     "url": "^0.11.0"

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -4,12 +4,13 @@ import * as React from "react";
 import RestfulReactProvider, { InjectedProps, RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
 import { composePath, composeUrl } from "./util/composeUrl";
 import { processResponse } from "./util/processResponse";
+import { resolveData } from "./util/resolveData";
 
 /**
  * A function that resolves returned data from
  * a fetch call.
  */
-export type ResolveFunction<T> = (data: any) => T;
+export type ResolveFunction<T> = ((data: any) => T) | ((data: any) => Promise<T>);
 
 export interface GetDataError<TError> {
   message: string;
@@ -237,7 +238,9 @@ class ContextlessGet<TData, TError> extends React.Component<
       return null;
     }
 
-    this.setState({ loading: false, data: resolve!(data) });
+    const resolved = await resolveData<TData, TError>({ data, resolve });
+
+    this.setState({ loading: false, data: resolved.data, error: resolved.error });
     return data;
   };
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,0 +1,12 @@
+// Shared types across exported components and utils
+//
+/**
+ * A function that resolves returned data from
+ * a fetch call.
+ */
+export type ResolveFunction<T> = ((data: any) => T) | ((data: any) => Promise<T>);
+
+export interface GetDataError<TError> {
+  message: string;
+  data: TError | string;
+}

--- a/src/util/resolveData.ts
+++ b/src/util/resolveData.ts
@@ -1,0 +1,32 @@
+import { GetDataError, ResolveFunction } from "../types";
+
+export const resolveData = async <TData, TError>({
+  data,
+  resolve,
+}: {
+  data: any;
+  resolve?: ResolveFunction<TData>;
+}): Promise<{ data: TData | null; error: GetDataError<TError> | null }> => {
+  let resolvedData: TData | null = null;
+  let resolveError: GetDataError<TError> | null = null;
+  try {
+    if (resolve) {
+      const resolvedDataOrPromise: TData | Promise<TData> = resolve(data);
+      resolvedData = (resolvedDataOrPromise as { then?: any }).then
+        ? ((await resolvedDataOrPromise) as TData)
+        : (resolvedDataOrPromise as TData);
+    } else {
+      resolvedData = data;
+    }
+  } catch (err) {
+    resolvedData = null;
+    resolveError = {
+      message: "RESOLVE_ERROR",
+      data: JSON.stringify(err),
+    };
+  }
+  return {
+    data: resolvedData,
+    error: resolveError,
+  };
+};


### PR DESCRIPTION
# Why

This PR fixes #57, adding support for validators that either throw runtime errors or work through a promise, extending the support for libraries like `yup`.

## Open questions

### Errors

The errors coming from this validation are standard and can produce anything, so they don't fit into the `{ message: string, data: TError | string }` interface - so as a first pass, I am passing a `RESOLVE_ERROR` string as message so it is easily recognizable, and stringifying the actual error inside `data` - which the end user would have to parse back into JSON later. Wonder if there is a better way to deal with this.