### PR TITLE
Cancel pending request when unmounting

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -118,6 +118,35 @@ describe("Get", () => {
       await wait(() => expect(children.mock.calls.length).toBe(2));
       expect(children.mock.calls[1][0]).toEqual({ hello: "world" });
     });
+
+    it("shouldn't resolve after component unmounts", async () => {
+      let requestResolves;
+      const pendingRequestFinishes = new Promise(resolvePromise => {
+        requestResolves = resolvePromise;
+      });
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .socketDelay(1000)
+        .reply(200, () => {
+          requestResolves();
+        });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+      const resolve = jest.fn((a: any) => a);
+
+      const { unmount } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" resolve={resolve}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      unmount();
+      await pendingRequestFinishes;
+      await wait(() => expect(resolve).not.toHaveBeenCalled());
+    });
   });
 
   describe("with error", () => {

--- a/src/util/makeCancelable.spec.ts
+++ b/src/util/makeCancelable.spec.ts
@@ -1,0 +1,42 @@
+import makeCancelable from "./makeCancelable";
+
+describe("makeCancelable", () => {
+  it("should resolve when promise resolves", async () => {
+    const future = new Promise(resolve => {
+      setTimeout(() => resolve("well done!"), 1000);
+    });
+    const pending = makeCancelable(future);
+    const response = await pending.promise;
+    expect(response).toBe("well done!");
+  });
+  it("should reject if promise cancels before resolving", async () => {
+    const future = new Promise(resolve => {
+      setTimeout(() => resolve("well done!"), 1000);
+    });
+    const pending = makeCancelable(future);
+    const next = jest.fn();
+    pending.cancel();
+    try {
+      await pending.promise;
+      next();
+    } catch (e) {
+      expect(e.isCancelled).toBe(true);
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
+  it("should reject if promise is rejected", async () => {
+    const future = new Promise((resolve, reject) => {
+      setTimeout(() => reject(new Error("oops")), 1000);
+    });
+    const pending = makeCancelable(future);
+    const next = jest.fn();
+    pending.cancel();
+    try {
+      await pending.promise;
+      next();
+    } catch (e) {
+      expect(e.message).toBe("oops");
+    }
+    expect(next).not.toHaveBeenCalled();
+  });
+});

--- a/src/util/makeCancelable.ts
+++ b/src/util/makeCancelable.ts
@@ -1,0 +1,22 @@
+export type CancelablePromise<T> = {
+  cancel: () => void;
+  isCancelled: () => boolean;
+  promise: Promise<T>;
+}
+
+const makeCancelable = (promise: Promise<any>): CancelablePromise<any> => {
+  let isCancelled = false;
+  return {
+    cancel() {
+      isCancelled = true;
+    },
+    isCancelled() {
+      return isCancelled;
+    },
+    promise: promise.then(
+      (value: any): Promise<any> => (isCancelled ? Promise.reject({ isCancelled }) : Promise.resolve(value)),
+    ),
+  };
+};
+
+export default makeCancelable;


### PR DESCRIPTION
# Why

To avoid side effects from unmounted components.

# Related issue

#71 


