### PR TITLE
Define behavior for fetch failure for Get, Mutate, and Poll.

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -231,6 +231,26 @@ describe("Get", () => {
       await wait(() => expect(children.mock.calls.length).toBe(2));
       expect(onError.mock.calls.length).toEqual(0);
     });
+
+    it("should call onError when fetch throws an exception", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .replyWithError("FAKE CERTIFICATE ERROR");
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onError = jest.fn();
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onError={onError}>
+          <Get path="">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(onError.mock.calls.length).toEqual(1);
+    });
   });
 
   describe("with custom resolver", () => {

--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -291,6 +291,31 @@ describe("Mutate", () => {
 
       expect(onError.mock.calls.length).toEqual(0);
     });
+
+    it("should call onError when fetch throws an exception", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .replyWithError("FAKE CERTIFICATE ERROR");
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onError = jest.fn();
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onError={onError}>
+          <Mutate verb="POST" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await children.mock.calls[0][0]().catch(() => {
+        /* noop */
+      });
+
+      expect(onError.mock.calls.length).toEqual(1);
+    });
   });
   describe("Compose paths and urls", () => {
     it("should compose absolute urls", async () => {

--- a/src/util/processResponse.ts
+++ b/src/util/processResponse.ts
@@ -2,17 +2,20 @@ export const processResponse = async (response: Response) => {
   if ((response.headers.get("content-type") || "").includes("application/json")) {
     try {
       return {
+        response,
         data: await response.json(),
         responseError: false,
       };
     } catch (e) {
       return {
+        response,
         data: e.message,
         responseError: true,
       };
     }
   } else {
     return {
+      response,
       data: await response.text(),
       responseError: false,
     };


### PR DESCRIPTION
Get and Mutate are pretty clear at how they should handle failure. Poll's behavior is to completely stop when a fetch fails. I don't understand how this is useful as you are probably using Poll to reach a desire state with your 'until' and can deal with the types of errors there. I haven't exposed the fetch errors with state because this would likely result in the until's function signature changing and I don't want to break API versions.

# Why

relates to #78 
