### PR TITLE
Fix an infinite loop on fetching without a resolve function

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -567,23 +567,14 @@ describe("Get", () => {
         .persist();
       const children = jest.fn();
       children.mockReturnValue(<div />);
-      const resolve = a => a;
-      /**
-       * A new instance of RestfulProvider is created on every rerender.
-       * This will create a new resolve function every time forcing Get to
-       * refetch.
-       * In a real app, only Get would be rerendered so resolve would be the
-       * same on every new render. To mimic that behavior, resolve is created
-       * ahead so Get will get the same instance on every rerender.
-       */
       const { rerender } = render(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="?test=1">{children}</Get>
         </RestfulProvider>,
       );
       times(10, i =>
         rerender(
-          <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+          <RestfulProvider base="https://my-awesome-api.fake">
             <Get path={`?test=${i + 1}`}>{children}</Get>
           </RestfulProvider>,
         ),
@@ -600,14 +591,13 @@ describe("Get", () => {
         .persist();
       const children = jest.fn();
       children.mockReturnValue(<div />);
-      const resolve = a => a;
       const { rerender } = render(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake" resolve={data => data}>
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
       rerender(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake" resolve={data => data}>
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
@@ -620,9 +610,8 @@ describe("Get", () => {
         .reply(200, () => ++apiCalls);
       const children = jest.fn();
       children.mockReturnValue(<div />);
-      const resolve = a => a;
       const { rerender } = render(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
@@ -630,7 +619,7 @@ describe("Get", () => {
         .get("/")
         .reply(200, () => ++apiCalls);
       rerender(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake">
           <Get base="https://my-new-api.fake" path="">
             {children}
           </Get>
@@ -647,14 +636,13 @@ describe("Get", () => {
         .persist();
       const children = jest.fn();
       children.mockReturnValue(<div />);
-      const resolve = a => a;
       const { rerender } = render(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/?test=0">{children}</Get>
         </RestfulProvider>,
       );
       rerender(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={resolve}>
+        <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/?test=1">{children}</Get>
         </RestfulProvider>,
       );
@@ -674,9 +662,9 @@ describe("Get", () => {
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
-      const newResolve = a => a;
+      const newResolve = () => "hello";
       rerender(
-        <RestfulProvider base="https://my-awesome-api.fake" resolve={providerResolve}>
+        <RestfulProvider base="https://my-awesome-api.fake" resolve={newResolve}>
           <Get path="" resolve={newResolve}>
             {children}
           </Get>

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -170,7 +170,8 @@ class ContextlessGet<TData, TError> extends React.Component<
       base !== this.props.base ||
       parentPath !== this.props.parentPath ||
       path !== this.props.path ||
-      resolve !== this.props.resolve
+      // both `resolve` props need to _exist_ first, and then be equivalent.
+      (resolve && this.props.resolve && resolve.toString() !== this.props.resolve.toString())
     ) {
       if (!this.props.lazy) {
         this.fetch();


### PR DESCRIPTION
# Why

On 6.0.0, we accidentally introduced a regression that rerenders the component infinitely if a `Get` does not have a `resolve` function and the request happens to error. This was introduced by incorrectly comparing resolve functions.

As a way of ensuring function-referential-equivalence, we now stringify the functions to make sure we only rerender when they _actually_ change.

<!-- Why did you make this PR? What problem does it solve? -->
