### PR TITLE
Fix base path propagation to ignore parentPath

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -6,6 +6,7 @@ import React from "react";
 import { cleanup, render, wait } from "react-testing-library";
 
 import { Get, RestfulProvider } from "./index";
+import Mutate from "./Mutate";
 
 afterEach(() => {
   cleanup();
@@ -602,6 +603,33 @@ describe("Get", () => {
         </RestfulProvider>,
       );
       expect(apiCalls).toEqual(1);
+    });
+
+    it("should rewrite the base and handle path accordingly", async () => {
+      nock("https://my-other-api.fake")
+        .get("/")
+        .reply(200, { id: 1 });
+
+      nock("https://my-awesome-api.fake/eaegae")
+        .post("/LOL")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake/eaegae">
+          <Mutate verb="POST" path="/LOL">
+            {() => (
+              <Get base="https://my-other-api.fake" path="">
+                {children}
+              </Get>
+            )}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
     });
     it("should refetch when base changes", () => {
       let apiCalls = 0;

--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -4,6 +4,7 @@ import nock from "nock";
 import React from "react";
 import { cleanup, render, wait } from "react-testing-library";
 
+import Get from "./Get";
 import { Mutate, RestfulProvider } from "./index";
 
 afterEach(() => {
@@ -399,6 +400,36 @@ describe("Mutate", () => {
       // after post state
       expect(children.mock.calls[2][1].loading).toEqual(false);
       expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+
+    it("should rewrite the base and handle path accordingly", async () => {
+      nock("https://my-other-api.fake")
+        .post("/")
+        .reply(200, { id: 1 });
+
+      nock("https://my-awesome-api.fake/eaegae")
+        .get("/LOL")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake/eaegae">
+          <Get path="/LOL">
+            {() => (
+              <Mutate verb="POST" base="https://my-other-api.fake" path="">
+                {children}
+              </Mutate>
+            )}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      const response = await children.mock.calls[0][0]();
+      expect(children.mock.calls.length).toBe(4);
+      expect(response).toEqual({ id: 1 });
     });
 
     it("should compose base with trailing slash", async () => {

--- a/src/util/composeUrl.ts
+++ b/src/util/composeUrl.ts
@@ -1,6 +1,6 @@
 import url from "url";
 
-export const composeUrl = (base: string, parentPath: string, path: string): string => {
+export const composeUrl = (base: string = "", parentPath: string = "", path: string = ""): string => {
   const composedPath = composePath(parentPath, path);
   /* If the base contains a trailing slash, it will be trimmed during composition */
   return base!.endsWith("/") ? `${base!.slice(0, -1)}${composedPath}` : `${base}${composedPath}`;
@@ -14,7 +14,7 @@ export const composeUrl = (base: string, parentPath: string, path: string): stri
  * whereas,
  * parentPath = "/someBasePath" and path = "relative" resolves to "/someBasePath/relative"
  */
-export const composePath = (parentPath: string, path: string): string => {
+export const composePath = (parentPath: string = "", path: string = ""): string => {
   if (path.startsWith("/") && path.length > 1) {
     return url.resolve(parentPath, path);
   } else if (path !== "" && path !== "/") {


### PR DESCRIPTION
# Why

Currently, the following snippet behaves a little unpredictably. Consider,

```jsx
        <RestfulProvider base="https://my-awesome-api.fake/eaegae">
          <Get path="/LOL">
            {() => (
              <Mutate verb="POST" base="https://my-other-api.fake" path="">
                {children}
              </Mutate>
            )}
          </Get>
        </RestfulProvider>
```

this makes a request to `https://my-other-api.fake/LOL` when the mutate function is called. This is incorrect. It needs to instead, ignore any parent path and defer to `Mutate`'s `path` property (the empty string) _only_, without composing the parent `Get`'s `path` property.

In order for this function to function (pun intended) correctly, the snippet _should_ send a request to `https://my-other-api.fake/`.

This PR fixes this and adds a test case across both `Get` _and_ `Mutate`.
<!-- Why did you make this PR? What problem does it solve? -->
