### PR TITLE
Add Response in the onError callback

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -26,7 +26,7 @@ export interface RestfulReactProviderProps<T = any> {
    * Depending of your case, it can be easier to add a `localErrorOnly` on your `Mutate` component
    * to deal with your retry locally instead of in the provider scope.
    */
-  onError?: (err: any, retry?: () => Promise<T | null>) => void;
+  onError?: (err: any, retry: () => Promise<T | null>, response: Response) => void;
 }
 
 const { Provider, Consumer: RestfulReactConsumer } = React.createContext<Required<RestfulReactProviderProps>>({

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -203,7 +203,8 @@ describe("Get", () => {
           data: { message: "You shall not pass!" },
           message: "Failed to fetch: 401 Unauthorized",
         },
-        expect.any(Function),
+        expect.any(Function), // retry
+        expect.any(Object), // response
       );
     });
 
@@ -232,7 +233,8 @@ describe("Get", () => {
           data: { message: "You shall not pass!" },
           message: "Failed to fetch: 401 Unauthorized",
         },
-        expect.any(Function),
+        expect.any(Function), // retry
+        expect.any(Object), // response
       );
       onError.mock.calls[0][1]();
       await wait(() => expect(children.mock.calls.length).toBe(4));

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -258,7 +258,7 @@ class ContextlessGet<TData, TError> extends React.Component<
       });
 
       if (!this.props.localErrorOnly && this.props.onError) {
-        this.props.onError(error, () => this.fetch(requestPath, thisRequestOptions));
+        this.props.onError(error, () => this.fetch(requestPath, thisRequestOptions), response);
       }
 
       return null;

--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -290,7 +290,8 @@ describe("Mutate", () => {
           data: { message: "You shall not pass!" },
           message: "Failed to fetch: 401 Unauthorized",
         },
-        expect.any(Function),
+        expect.any(Function), // retry
+        expect.any(Object), // response
       );
     });
 
@@ -325,7 +326,8 @@ describe("Mutate", () => {
           data: { message: "You shall not pass!" },
           message: "Failed to fetch: 401 Unauthorized",
         },
-        expect.any(Function),
+        expect.any(Function), // retry
+        expect.any(Object), // response
       );
       const data = await onError.mock.calls[0][1]();
       expect(data).toEqual({ message: "You shall pass :)" });

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -183,7 +183,7 @@ class ContextlessMutate<TData, TError> extends React.Component<
       });
 
       if (!this.props.localErrorOnly && this.props.onError) {
-        this.props.onError(error, () => this.mutate(body, mutateRequestOptions));
+        this.props.onError(error, () => this.mutate(body, mutateRequestOptions), response);
       }
 
       throw error;

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -354,10 +354,14 @@ describe("Poll", () => {
       );
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
-      expect(onError).toBeCalledWith({
-        data: { message: "You shall not pass!" },
-        message: "Failed to poll: 401 Unauthorized",
-      });
+      expect(onError).toBeCalledWith(
+        {
+          data: { message: "You shall not pass!" },
+          message: "Failed to poll: 401 Unauthorized",
+        },
+        expect.any(Function), // retry
+        expect.any(Object), // response
+      );
     });
 
     it("should set the `error` object properly", async () => {

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -240,7 +240,7 @@ class ContextlessPoll<TData, TError> extends React.Component<
         this.setState({ loading: false, lastResponse: response, error });
 
         if (!this.props.localErrorOnly && this.props.onError) {
-          this.props.onError(error);
+          this.props.onError(error, () => Promise.resolve(), response);
         }
       } else if (this.isModified(response, data)) {
         this.setState(prevState => ({


### PR DESCRIPTION
# Why

The idea is to add `response` as extra argument of `onError` to have access to the `url`, `status`, etc for better debugging