### PR TITLE
Fix React import on generated d.ts

### DIFF
--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -1,4 +1,4 @@
-import React from "react";
+import * as React from "react";
 import equal from "react-fast-compare";
 
 import { InjectedProps, RestfulReactConsumer } from "./Context";


### PR DESCRIPTION
React should be imported with * because of React.ReactNode is not being exported with React Object I'm using TSX

# Why
After installing the package it throws an error React `has no default export`
![image](https://user-images.githubusercontent.com/35136/48763909-9864af00-ecae-11e8-8182-8fd1e53d2a9e.png)

<!-- Why did you make this PR? What problem does it solve? -->
