### PR TITLE
Fix Get reload on queryParams change

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -730,6 +730,33 @@ describe("Get", () => {
       );
       expect(apiCalls).toEqual(2);
     });
+    it("should refetch when queryParams changes", () => {
+      let apiCalls = 0;
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, () => ++apiCalls)
+        .persist();
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({ page: 2 })
+        .reply(200, () => ++apiCalls)
+        .persist();
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+      const { rerender } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="">{children}</Get>
+        </RestfulProvider>,
+      );
+      rerender(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" queryParams={{ page: 2 }}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+      expect(apiCalls).toEqual(2);
+    });
   });
   describe("Compose paths and urls", () => {
     it("should compose the url with the base", async () => {

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -181,11 +181,12 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
   }
 
   public componentDidUpdate(prevProps: GetProps<TData, TError, TQueryParams>) {
-    const { base, parentPath, path, resolve } = prevProps;
+    const { base, parentPath, path, resolve, queryParams } = prevProps;
     if (
       base !== this.props.base ||
       parentPath !== this.props.parentPath ||
       path !== this.props.path ||
+      queryParams !== this.props.queryParams ||
       // both `resolve` props need to _exist_ first, and then be equivalent.
       (resolve && this.props.resolve && resolve.toString() !== this.props.resolve.toString())
     ) {


### PR DESCRIPTION
# Why

Because it can be cool to refetch when we change the `page` in `queryParams` 😅 