### PR TITLE
Fix infinite request loop because of queryParam equality

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -756,6 +756,31 @@ describe("Get", () => {
       );
       expect(apiCalls).toEqual(2);
     });
+    it("should NOT refetch when queryParams are the same", () => {
+      let apiCalls = 0;
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({ page: 2 })
+        .reply(200, () => ++apiCalls)
+        .persist();
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+      const { rerender } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" queryParams={{ page: 2 }}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+      rerender(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" queryParams={{ page: 2 }}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+      expect(apiCalls).toEqual(1);
+    });
     it("should refetch when queryParams changes", () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -1,7 +1,9 @@
 import { DebounceSettings } from "lodash";
 import debounce from "lodash/debounce";
+import isEqual from "lodash/isEqual";
 import * as qs from "qs";
 import * as React from "react";
+
 import RestfulReactProvider, { InjectedProps, RestfulReactConsumer, RestfulReactProviderProps } from "./Context";
 import { composePath, composeUrl } from "./util/composeUrl";
 import { processResponse } from "./util/processResponse";
@@ -187,7 +189,7 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
       base !== this.props.base ||
       parentPath !== this.props.parentPath ||
       path !== this.props.path ||
-      queryParams !== this.props.queryParams ||
+      !isEqual(queryParams, this.props.queryParams) ||
       // both `resolve` props need to _exist_ first, and then be equivalent.
       (resolve && this.props.resolve && resolve.toString() !== this.props.resolve.toString())
     ) {


### PR DESCRIPTION
# Why
We were comparing queryParams for equality and it was always false, leading to infinite rerenders and DDoS attacks.

This PR fixes this.

<!-- Why did you make this PR? What problem does it solve? -->
