### PR TITLE
Fix useGet

### DIFF
--- a/package.json
+++ b/package.json
@@ -94,6 +94,6 @@
     "yamljs": "^0.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.3"
+    "react": "^16.8.4"
   }
 }

--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -444,6 +444,28 @@ describe("useGet hook", () => {
 
       expect(getByTestId("data")).toHaveTextContent("my god 😍");
     });
+
+    it("should merge headers with providers", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar", bar: "foo" } })
+        .get("/")
+        .reply(200, { oh: "my god 😍" });
+
+      const MyAwesomeComponent = () => {
+        const { data, loading } = useGet<{ oh: string }>({ path: "/", requestOptions: { headers: { foo: "bar" } } });
+
+        return loading ? <div data-testid="loading">Loading…</div> : <div data-testid="data">{data.oh}</div>;
+      };
+
+      const { getByTestId } = render(
+        <RestfulProvider base="https://my-awesome-api.fake" requestOptions={() => ({ headers: { bar: "foo" } })}>
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      await waitForElement(() => getByTestId("data"));
+
+      expect(getByTestId("data")).toHaveTextContent("my god 😍");
+    });
   });
 
   describe("actions", () => {

--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -57,6 +57,28 @@ describe("useGet hook", () => {
       expect(getByTestId("data")).toHaveTextContent("my god 😍");
     });
 
+    it("should have data from the request after loading (alternative syntax)", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { oh: "my god 😍" });
+
+      const MyAwesomeComponent = () => {
+        const { data, loading } = useGet<{ oh: string }>("/");
+
+        return loading ? <div data-testid="loading">Loading…</div> : <div data-testid="data">{data.oh}</div>;
+      };
+
+      const { getByTestId } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      await waitForElement(() => getByTestId("data"));
+
+      expect(getByTestId("data")).toHaveTextContent("my god 😍");
+    });
+
     it("shouldn't resolve after component unmount", async () => {
       let requestResolves;
       const pendingRequestFinishes = new Promise(resolvePromise => {

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -127,9 +127,34 @@ const isCancellable = <T extends (...args: any[]) => any>(func: T): func is T & 
   return typeof (func as any).cancel === "function" && typeof (func as any).flush === "function";
 };
 
+export interface UseGetReturn<TData, TError> extends GetState<TData, TError> {
+  /**
+   * Absolute path resolved from `base` and `path` (context & local)
+   */
+  absolutePath: string;
+  /**
+   * Cancel the current fetch
+   */
+  cancel: () => void;
+  /**
+   * Refetch
+   */
+  refetch: () => Promise<void>;
+}
+
+export function useGet<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
+  path: string,
+  props?: Omit<UseGetProps<TData, TQueryParams>, "path">,
+): UseGetReturn<TData, TError>;
+
 export function useGet<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
   props: UseGetProps<TData, TQueryParams>,
-) {
+): UseGetReturn<TData, TError>;
+
+export function useGet<TData = any, TError = any, TQueryParams = { [key: string]: any }>() {
+  const props: UseGetProps<TData, TError> =
+    typeof arguments[0] === "object" ? arguments[0] : { ...arguments[1], path: arguments[0] };
+
   const context = useContext(Context);
 
   const fetchData = useCallback<CancellableFetchData>(

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -1,5 +1,6 @@
 import { Cancelable, DebounceSettings } from "lodash";
 import debounce from "lodash/debounce";
+import merge from "lodash/merge";
 import qs from "qs";
 import { useCallback, useContext, useEffect, useRef, useState } from "react";
 import url from "url";
@@ -77,12 +78,15 @@ async function _fetchData<TData, TError, TQueryParams>(
 
   const requestOptions =
     (typeof props.requestOptions === "function" ? props.requestOptions() : props.requestOptions) || {};
-  requestOptions.headers = new Headers(requestOptions.headers);
 
-  const request = new Request(url.resolve(base, queryParams ? `${path}?${qs.stringify(queryParams)}` : path), {
-    ...requestOptions,
-    signal,
-  });
+  const contextRequestOptions =
+    (typeof context.requestOptions === "function" ? context.requestOptions() : context.requestOptions) || {};
+
+  const request = new Request(
+    url.resolve(base, queryParams ? `${path}?${qs.stringify(queryParams)}` : path),
+    merge(contextRequestOptions, requestOptions, { signal }),
+  );
+
   try {
     const response = await fetch(request);
     const { data, responseError } = await processResponse(response);


### PR DESCRIPTION
# Why

The `requestOptions` was not correctly consolidate, this is fixed!

Also I add a bit of sugar to permit the following API:

```ts
const {data, loading, error} = useGet("/");
```

Finally a little fix about react dependency.

This will test on the `@next` release to be sure everything is following in a real project 