### PR TITLE
Fix/use get error clearing

### DIFF
--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -294,6 +294,48 @@ describe("useGet hook", () => {
       expect(getByTestId("data")).toHaveTextContent("You shall pass :)");
     });
 
+    it("should clear up the old error on refetching", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({ page: 1 })
+        .reply(404, { id: 0 });
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({ page: 2 })
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const MyAwesomeComponent = ({ path }) => {
+        const [page, setPage] = useState(1);
+        const params = useGet<{ id: number }, any, { page: number }>({ path, queryParams: { page } });
+
+        return (
+          <>
+            <button data-testid="set-page-button" onClick={() => setPage(2)} />
+            {children(params)}
+          </>
+        );
+      };
+
+      const { getByTestId } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <MyAwesomeComponent path="" />
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children).toBeCalledTimes(2));
+
+      fireEvent.click(getByTestId("set-page-button"));
+
+      await wait(() => expect(children).toBeCalledTimes(5));
+      expect(children.mock.calls[1][0].error).not.toEqual(null);
+      expect(children.mock.calls[4][0].loading).toEqual(false);
+      expect(children.mock.calls[4][0].data).toEqual({ id: 1 });
+      expect(children.mock.calls[4][0].error).toEqual(null);
+    });
+
     it("should not call the provider onError if localErrorOnly is true", async () => {
       nock("https://my-awesome-api.fake")
         .get("/")

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -93,7 +93,9 @@ async function _fetchData<TData, TError, TQueryParams>(
 
     if (signal.aborted) {
       return;
-    } else if (!response.ok || responseError) {
+    }
+
+    if (!response.ok || responseError) {
       const error = {
         message: `Failed to fetch: ${response.status} ${response.statusText}${responseError ? " - " + data : ""}`,
         data,
@@ -105,9 +107,10 @@ async function _fetchData<TData, TError, TQueryParams>(
       if (!props.localErrorOnly && context.onError) {
         context.onError(error, () => _fetchData(props, state, setState, context, abortController), response);
       }
-    } else {
-      setState({ ...state, error: null, loading: false, data: resolve(data) });
+      return;
     }
+
+    setState({ ...state, error: null, loading: false, data: resolve(data) });
   } catch (e) {
     setState({
       ...state,

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -106,7 +106,7 @@ async function _fetchData<TData, TError, TQueryParams>(
         context.onError(error, () => _fetchData(props, state, setState, context, abortController), response);
       }
     } else {
-      setState({ ...state, loading: false, data: resolve(data) });
+      setState({ ...state, error: null, loading: false, data: resolve(data) });
     }
   } catch (e) {
     setState({


### PR DESCRIPTION
# Why
Fixes the issue, that if a fetch returns an error, this error is still being returned for all the subsequent successful fetches.
