### PR TITLE
Add requestOptions in the watch list for refetch

### DIFF
--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -192,7 +192,7 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
       abortController.current.abort();
       abortController.current = new AbortController();
     };
-  }, [props.path, props.base, props.resolve, props.queryParams]);
+  }, [props.path, props.base, props.resolve, props.queryParams, props.requestOptions]);
 
   return {
     ...state,


### PR DESCRIPTION
# Why

A little hotfix on the next version, I forgot `requestOptions` in the dependencies list
