### PR TITLE
Add support for requestOptions as a method to Poll

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -544,6 +544,27 @@ describe("Get", () => {
       expect(children.mock.calls[1][1].loading).toEqual(false);
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
+
+    it("should add a custom header with requestOptions method", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" requestOptions={() => ({ headers: { foo: "bar" } })}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
   });
 
   describe("actions", () => {

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -678,5 +678,26 @@ describe("Poll", () => {
       expect(children.mock.calls[1][1].loading).toEqual(false);
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
+
+    it("should merge headers with providers", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar", baz: "qux" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" requestOptions={{ headers: { baz: "qux" } }}>
+          <Poll path="" requestOptions={() => ({ headers: { foo: "bar" } })}>
+            {children}
+          </Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
   });
 });

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -657,5 +657,26 @@ describe("Poll", () => {
       expect(children.mock.calls[1][1].loading).toEqual(false);
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
+
+    it("should add a custom header with requestOptions method", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Poll path="" requestOptions={() => ({ headers: { foo: "bar" } })}>
+            {children}
+          </Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
   });
 });

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -1,3 +1,4 @@
+import merge from "lodash/merge";
 import * as qs from "qs";
 import * as React from "react";
 import equal from "react-fast-compare";
@@ -351,10 +352,7 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
           <ContextlessPoll
             {...contextProps}
             {...props}
-            requestOptions={{
-              ...contextRequestOptions,
-              ...propsRequestOptions,
-            }}
+            requestOptions={merge(contextRequestOptions, propsRequestOptions)}
           />
         );
       }}

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -339,16 +339,25 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
   // Compose Contexts to allow for URL nesting
   return (
     <RestfulReactConsumer>
-      {contextProps => (
-        <ContextlessPoll
-          {...contextProps}
-          {...props}
-          requestOptions={{
-            ...contextProps.requestOptions,
-            ...props.requestOptions,
-          }}
-        />
-      )}
+      {contextProps => {
+        const contextRequestOptions =
+          typeof contextProps.requestOptions === "function"
+            ? contextProps.requestOptions()
+            : contextProps.requestOptions || {};
+        const propsRequestOptions =
+          typeof props.requestOptions === "function" ? props.requestOptions() : props.requestOptions || {};
+
+        return (
+          <ContextlessPoll
+            {...contextProps}
+            {...props}
+            requestOptions={{
+              ...contextRequestOptions,
+              ...propsRequestOptions,
+            }}
+          />
+        );
+      }}
     </RestfulReactConsumer>
   );
 }


### PR DESCRIPTION
# Why

Fixes #112 

I'm not sure this is a proper way, but it works. Get / Poll seem to be quite different and sadly I didn't have much time to dig into the source code.