### PR TITLE
Fix useGet url composition pattern

### DIFF
--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -113,14 +113,19 @@ describe("useGet hook", () => {
     [
       { base: "https://my-awesome-api.fake", path: "/", expected: ["https://my-awesome-api.fake", "/"] },
       { base: "https://my-awesome-api.fake", path: "/plop", expected: ["https://my-awesome-api.fake", "/plop"] },
-      { base: "https://my-awesome-api.fake/plop", path: "/", expected: ["https://my-awesome-api.fake", "/"] },
-      { base: "https://my-awesome-api.fake/plop/", path: "/", expected: ["https://my-awesome-api.fake", "/"] },
+      { base: "https://my-awesome-api.fake/plop", path: "/", expected: ["https://my-awesome-api.fake", "/plop/"] },
+      { base: "https://my-awesome-api.fake/plop/", path: "/", expected: ["https://my-awesome-api.fake", "/plop/"] },
       { base: "https://my-awesome-api.fake/plop/", path: "", expected: ["https://my-awesome-api.fake", "/plop/"] },
       { base: "https://my-awesome-api.fake/plop/", path: "../", expected: ["https://my-awesome-api.fake", "/"] },
-      { base: "https://my-awesome-api.fake/a", path: "/b", expected: ["https://my-awesome-api.fake", "/b"] },
+      { base: "https://my-awesome-api.fake/a", path: "/b", expected: ["https://my-awesome-api.fake", "/a/b"] },
+      {
+        base: "https://my-awesome-api.fake/a",
+        path: "/tejas/",
+        expected: ["https://my-awesome-api.fake", "/a/tejas/"],
+      },
       { base: "https://my-awesome-api.fake/a/", path: "", expected: ["https://my-awesome-api.fake", "/a/"] },
-    ].forEach(({ base, path, expected }) => {
-      it(`should call ${expected.join("")}`, async () => {
+    ].forEach(({ base, path, expected }, i) => {
+      it(`should call ${expected.join("")}(${i})`, async () => {
         nock(expected[0])
           .get(expected[1])
           .reply(200, { oh: "my god 😍" });
@@ -442,6 +447,7 @@ describe("useGet hook", () => {
       expect(children).toHaveBeenCalledWith({ data: null, error: null, loading: false });
     });
   });
+
   describe("with base", () => {
     it("should override the base url", async () => {
       nock("https://my-awesome-api.fake")
@@ -710,6 +716,7 @@ describe("useGet hook", () => {
       expect(resolve).not.toHaveBeenCalled();
     });
   });
+
   describe("refetch after update", () => {
     it("should not refetch when base, path or resolve don't change", () => {
       let apiCalls = 0;

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -57,10 +57,10 @@ export interface UseGetProps<TData, TQueryParams> {
 }
 
 function resolvePath<TQueryParams>(base: string, path: string, queryParams: TQueryParams) {
-  const escapedBase = base.endsWith("/") ? base : `${base}/`;
-  const escapedPath = path.startsWith("/") ? path.slice(1) : path;
+  const appendedBase = base.endsWith("/") ? base : `${base}/`;
+  const trimmedPath = path.startsWith("/") ? path.slice(1) : path;
 
-  return url.resolve(escapedBase, queryParams ? `${escapedPath}?${qs.stringify(queryParams)}` : escapedPath);
+  return url.resolve(appendedBase, queryParams ? `${trimmedPath}?${qs.stringify(queryParams)}` : trimmedPath);
 }
 
 async function _fetchData<TData, TError, TQueryParams>(

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -56,6 +56,13 @@ export interface UseGetProps<TData, TQueryParams> {
     | number;
 }
 
+function resolvePath<TQueryParams>(base: string, path: string, queryParams: TQueryParams) {
+  const escapedBase = base.endsWith("/") ? base : `${base}/`;
+  const escapedPath = path.startsWith("/") ? path.slice(1) : path;
+
+  return url.resolve(escapedBase, queryParams ? `${escapedPath}?${qs.stringify(queryParams)}` : escapedPath);
+}
+
 async function _fetchData<TData, TError, TQueryParams>(
   props: UseGetProps<TData, TQueryParams>,
   state: GetState<TData, TError>,
@@ -83,7 +90,7 @@ async function _fetchData<TData, TError, TQueryParams>(
     (typeof context.requestOptions === "function" ? context.requestOptions() : context.requestOptions) || {};
 
   const request = new Request(
-    url.resolve(base, queryParams ? `${path}?${qs.stringify(queryParams)}` : path),
+    resolvePath(base, path, queryParams),
     merge(contextRequestOptions, requestOptions, { signal }),
   );
 
@@ -196,10 +203,7 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
 
   return {
     ...state,
-    absolutePath: url.resolve(
-      props.base || context.base,
-      props.queryParams ? `${props.path}?${qs.stringify(props.queryParams)}` : props.path,
-    ),
+    absolutePath: resolvePath(props.base || context.base, props.path, props.queryParams),
     cancel: () => {
       setState({
         ...state,


### PR DESCRIPTION
# Why

By lazyness, I've choose `url.resolve` composition pattern when I implement the first version of `useGet`, the problem is that it required to add a trailing slash to the `Provider.base` to be able to use the library…

To resolve this, I update a bit the pattern, to permit more convenient url composition, not sure that is yet perfect but it will be test in our internals applications to validate the usage and pattern :wink:
