### PR TITLE
Avoid to use reserved keyword in the example

### DIFF
--- a/README.md
+++ b/README.md
@@ -373,8 +373,8 @@ const Movies = ({ dispatch }) => (
           <li>
             {movie.name}
             <Mutate verb="DELETE">
-              {(delete, {loading: isDeleting}) => (<button
-                      onClick={() => delete(movie.id).then(() => dispatch('DELETED'))}
+              {(deleteMovie, {loading: isDeleting}) => (<button
+                      onClick={() => deleteMovie(movie.id).then(() => dispatch('DELETED'))}
                       loading={isDeleting}
                     >
                       Delete!


### PR DESCRIPTION
# Why

`delete` is a reserved keyword in javascript world, let's use something else to have a working example.
