### PR TITLE
Propagate the error on Mutate

### DIFF
--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -294,6 +294,11 @@ describe("Mutate", () => {
           message: "Failed to fetch: 500 Internal Server Error",
           status: 500,
         });
+        expect(children.mock.calls[2][1].error).toEqual({
+          data: { error: "oh no… not again…" },
+          message: "Failed to fetch: 500 Internal Server Error",
+          status: 500,
+        });
       });
     });
 

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -178,6 +178,7 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
       };
 
       this.setState({
+        error,
         loading: false,
       });
 


### PR DESCRIPTION
# Why

The error in `Mutate` was never propagated to the component, we always used `.catch` but it's a legitim usecase and expectation 😅 

Thanks @AJHenry from the reporting 👍 

# Related issue

#121