### PR TITLE
Fix delete without id case

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -257,7 +257,7 @@ export const generateRestfulComponent = (
   route = route.replace(/\{/g, "${"); // `/pet/{id}` => `/pet/${id}`
 
   // Remove the last param of the route if we are in the DELETE case
-  let lastParamInTheRoute: string;
+  let lastParamInTheRoute: string | null = null;
   if (verb === "delete") {
     const lastParamInTheRouteRegExp = /\/\$\{(\w+)\}$/;
     lastParamInTheRoute = (route.match(lastParamInTheRouteRegExp) || [])[1];
@@ -324,7 +324,7 @@ export const generateRestfulComponent = (
         }`
       : `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${errorTypes}, ${
           queryParamsType ? componentName + "QueryParams" : "void"
-        }, ${verb === "delete" ? "string" : requestBodyTypes}`;
+        }, ${verb === "delete" && lastParamInTheRoute ? "string" : requestBodyTypes}`;
 
   const genericsTypesForHooksProps =
     verb === "get"

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -1238,11 +1238,11 @@ export interface JobRunResponse {}
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}/secret", [])).toMatchInlineSnapshot(`
         "
-        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
         // Delete use case
         export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
-          <Mutate<void, APIError, void, string>
+          <Mutate<void, APIError, void, void>
             verb=\\"DELETE\\"
             path={\`/use-cases/\${useCaseId}/secret\`}
             {...props}
@@ -1252,7 +1252,7 @@ export interface JobRunResponse {}
         export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
         // Delete use case
-        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
+        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
 
         "
       `);


### PR DESCRIPTION
# Why

Little case forgot during the last refactor, delete route without `id` at the end should be `void`, not `string`
