### PR TITLE
fix/132 handle fetch error mutate

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -26,7 +26,7 @@ export interface RestfulReactProviderProps<T = any> {
    * Depending of your case, it can be easier to add a `localErrorOnly` on your `Mutate` component
    * to deal with your retry locally instead of in the provider scope.
    */
-  onError?: (err: any, retry: () => Promise<T | null>, response: Response) => void;
+  onError?: (err: any, retry: () => Promise<T | null>, response?: Response) => void;
 }
 
 export const Context = React.createContext<Required<RestfulReactProviderProps>>({

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -162,7 +162,27 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
       },
     } as RequestInit); // Type assertion for version of TypeScript that can't yet discriminate.
 
-    const response = await fetch(request, { signal: this.signal });
+    let response: Response;
+    try {
+      response = await fetch(request, { signal: this.signal });
+    } catch (e) {
+      const error = {
+        message: "Failed to fetch" + e.message ? `: ${e.message}` : "",
+        data: "",
+      };
+
+      this.setState({
+        error,
+        loading: false,
+      });
+
+      if (!this.props.localErrorOnly && this.props.onError) {
+        this.props.onError(error, () => this.mutate(body, mutateRequestOptions));
+      }
+
+      throw error;
+    }
+
     const { data, responseError } = await processResponse(response);
 
     // avoid state updates when component has been unmounted

--- a/src/useMutate.tsx
+++ b/src/useMutate.tsx
@@ -92,7 +92,27 @@ export function useMutate<
         merge({}, contextRequestOptions, options, propsRequestOptions, mutateRequestOptions, { signal }),
       );
 
-      const response = await fetch(request);
+      let response: Response;
+      try {
+        response = await fetch(request);
+      } catch (e) {
+        const error = {
+          message: "Failed to fetch" + e.message ? `: ${e.message}` : "",
+          data: "",
+        };
+
+        setState({
+          error,
+          loading: false,
+        });
+
+        if (!props.localErrorOnly && context.onError) {
+          context.onError(error, () => mutate(body, mutateRequestOptions));
+        }
+
+        throw error;
+      }
+
       const { data: rawData, responseError } = await processResponse(response);
 
       let data: TData | any; // `any` -> data in error case


### PR DESCRIPTION
# Why
1. Wraps fetch call into try/catch to handle if fetch call returns an error, i.e when offline. Also passes 
the error to the RestfulProvider.
1. Makes response optional for the error callback for this case

# Issue
https://github.com/contiamo/restful-react/issues/132

# How to test: 
See the case in the linked issue
