### PR TITLE
**Fix**: unify error format 

### DIFF
--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -167,7 +167,7 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
       response = await fetch(request, { signal: this.signal });
     } catch (e) {
       const error = {
-        message: "Failed to fetch" + e.message ? `: ${e.message}` : "",
+        message: `Failed to fetch: ${e.message}`,
         data: "",
       };
 

--- a/src/useMutate.tsx
+++ b/src/useMutate.tsx
@@ -97,7 +97,7 @@ export function useMutate<
         response = await fetch(request);
       } catch (e) {
         const error = {
-          message: "Failed to fetch" + e.message ? `: ${e.message}` : "",
+          message: `Failed to fetch: ${e.message}`,
           data: "",
         };
 


### PR DESCRIPTION
# Why
Makes catch case message of the Mutate call and makes it same as for Get

