### PR TITLE
Add a onMutate callback.

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -102,5 +102,4 @@ package-lock.json
 
 # Files managed by operational-scripts
 tslint.json
-tsconfig.json
 .prettierrc

--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -431,7 +431,34 @@ describe("Mutate", () => {
 
       // No `expect` here, it's just to test if the types are correct 😉
     });
+
+    it("should call onMutate", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onMutate = jest.fn();
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Mutate verb="POST" path="" onMutate={onMutate}>
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      // call mutate
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      await children.mock.calls[0][0]();
+
+      expect(onMutate).toHaveBeenCalled();
+    });
   });
+
   describe("PUT", () => {
     it("should deal with empty response", async () => {
       nock("https://my-awesome-api.fake")

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -76,6 +76,13 @@ export interface MutateProps<TData, TError, TQueryParams, TRequestBody> {
    * @param actions - a key/value map of HTTP verbs, aliasing destroy to DELETE.
    */
   children: (mutate: MutateMethod<TData, TRequestBody>, states: States<TData, TError>, meta: Meta) => React.ReactNode;
+  /**
+   * Callback called after the mutation is done.
+   *
+   * @param body - Body given to mutate
+   * @param data - Response data
+   */
+  onMutate?: (body: TRequestBody, data: TData) => void;
 }
 
 /**
@@ -209,6 +216,11 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
     }
 
     this.setState({ loading: false });
+
+    if (this.props.onMutate) {
+      this.props.onMutate(body, data);
+    }
+
     return data;
   };
 

--- a/src/useMutate.test.tsx
+++ b/src/useMutate.test.tsx
@@ -218,6 +218,20 @@ describe("useMutate", () => {
       }
     });
 
+    it("should call onMutation", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .reply(200, { ok: true });
+
+      const wrapper = ({ children }) => (
+        <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
+      );
+      const onMutate = jest.fn();
+      const { result } = renderHook(() => useMutate("POST", "", { onMutate }), { wrapper });
+      await result.current.mutate({ foo: "bar" });
+      expect(onMutate).toHaveBeenCalled();
+    });
+
     it("should deal with non standard server error response (nginx style)", async () => {
       nock("https://my-awesome-api.fake")
         .post("/")
@@ -407,7 +421,7 @@ describe("useMutate", () => {
       }
 
       type UseDeleteMyCustomEndpoint = Omit<
-        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointQueryParams>,
+        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointQueryParams, {}>,
         "path" | "verb"
       >;
       const useDeleteMyCustomEndpoint = (props?: UseDeleteMyCustomEndpoint) =>
@@ -454,7 +468,7 @@ describe("useMutate", () => {
       }
 
       type UseDeleteMyCustomEndpoint = Omit<
-        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointQueryParams>,
+        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointQueryParams, {}>,
         "path" | "verb"
       >;
       const useDeleteMyCustomEndpoint = (props?: UseDeleteMyCustomEndpoint) =>

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -1,0 +1,25 @@
+{
+  "exclude": ["node_modules", "dist", "lib", "__tests__", "**/*.test*", "**/*.spec*"],
+  "include": ["src"],
+  "compilerOptions": {
+    "skipLibCheck": true,
+    "target": "es5",
+    "module": "esnext",
+    "lib": ["es2015", "dom", "es2016.array.include", "es2017.object"],
+    "jsx": "react",
+    "declaration": true,
+    "declarationMap": true,
+    "rootDir": "./src",
+    "outDir": "./lib",
+    "downlevelIteration": true,
+    "strict": true,
+    "noUnusedLocals": true,
+    "noUnusedParameters": true,
+    "noImplicitReturns": true,
+    "noFallthroughCasesInSwitch": true,
+    "moduleResolution": "node",
+    "allowSyntheticDefaultImports": true,
+    "esModuleInterop": true,
+    "inlineSourceMap": true
+  }
+}


### PR DESCRIPTION
# Why

I need a onMutate callback to unvalidate some cache, the plan is to slowly introduce some caching strategy, not yet sure how we want to this but a `onMutate` callback can be useful for many situation.

For now I just have a `memoize` function around our restful-react getter, and the idea is to unvalidate the cache on every related mutation 😉 
