### PR TITLE
Watch for lazy change in useGet

### DIFF
--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -199,7 +199,7 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
       abortController.current.abort();
       abortController.current = new AbortController();
     };
-  }, [props.path, props.base, props.resolve, props.queryParams, props.requestOptions]);
+  }, [props.lazy, props.path, props.base, props.resolve, props.queryParams, props.requestOptions]);
 
   return {
     ...state,


### PR DESCRIPTION
# Why

This change will allow to use `lazy` prop to skip immediate loading of results. We need this because we can't put hooks inside `if`