### PR TITLE
CLI improvements

### DIFF
--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -182,6 +182,7 @@ if (program.config) {
         })
         .catch(err => {
           log(chalk.red(err));
+          process.exit(1);
         });
     });
 } else {
@@ -198,5 +199,6 @@ if (program.config) {
     })
     .catch(err => {
       log(chalk.red(err));
+      process.exit(1);
     });
 }

--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -37,6 +37,11 @@ program.option("--validation", "add the validation step (provided by ibm-openapi
 program.option("--config [value]", "override flags by a config file");
 program.parse(process.argv);
 
+const createSuccessMessage = (backend?: string) =>
+  chalk.green(`${backend} 🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`);
+
+const successWithoutOutputMessage = chalk.yellow("Success! No output path specified; printed to standard output.");
+
 const importSpecs = async (options: AdvancedOptions) => {
   const transformer = options.transformer ? require(join(process.cwd(), options.transformer)) : undefined;
 
@@ -170,14 +175,10 @@ if (program.config) {
         .then(data => {
           if (options.output) {
             writeFileSync(join(process.cwd(), options.output), data);
-            log(
-              chalk.green(
-                `[${backend}] 🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`,
-              ),
-            );
+            log(createSuccessMessage(backend));
           } else {
             log(data);
-            log(chalk.yellow("Success! No output path specified; printed to standard output."));
+            log(successWithoutOutputMessage);
           }
         })
         .catch(err => {
@@ -191,10 +192,10 @@ if (program.config) {
     .then(data => {
       if (program.output) {
         writeFileSync(join(process.cwd(), program.output), data);
-        log(chalk.green(`🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`));
+        log(createSuccessMessage());
       } else {
         log(data);
-        log(chalk.yellow("Success! No output path specified; printed to standard output."));
+        log(successWithoutOutputMessage);
       }
     })
     .catch(err => {

--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -40,9 +40,6 @@ program.parse(process.argv);
 const importSpecs = async (options: AdvancedOptions) => {
   const transformer = options.transformer ? require(join(process.cwd(), options.transformer)) : undefined;
 
-  if (!options.output) {
-    throw new Error("You need to provide an output file with `--output`");
-  }
   if (!options.file && !options.github) {
     throw new Error("You need to provide an input specification with `--file` or `--github`");
   }
@@ -171,12 +168,17 @@ if (program.config) {
     .forEach(([backend, options]) => {
       importSpecs(options)
         .then(data => {
-          writeFileSync(join(process.cwd(), options.output), data);
-          log(
-            chalk.green(
-              `[${backend}] 🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`,
-            ),
-          );
+          if (options.output) {
+            writeFileSync(join(process.cwd(), options.output), data);
+            log(
+              chalk.green(
+                `[${backend}] 🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`,
+              ),
+            );
+          } else {
+            log(data);
+            log(chalk.yellow("Success! No output path specified; printed to standard output."));
+          }
         })
         .catch(err => {
           log(chalk.red(err));
@@ -186,8 +188,13 @@ if (program.config) {
   // Use flags as configuration
   importSpecs((program as any) as Options)
     .then(data => {
-      writeFileSync(join(process.cwd(), program.output), data);
-      log(chalk.green(`🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`));
+      if (program.output) {
+        writeFileSync(join(process.cwd(), program.output), data);
+        log(chalk.green(`🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`));
+      } else {
+        log(data);
+        log(chalk.yellow("Success! No output path specified; printed to standard output."));
+      }
     })
     .catch(err => {
       log(chalk.red(err));


### PR DESCRIPTION
# Why
This PR fixes #154 and also makes the `--output` option optional, printing to standard output in case there is no output specified. This is useful for dry runs and a common pattern for CLI tools (see babel).

<!-- Why did you make this PR? What problem does it solve? -->
