### PR TITLE
Support Global queryparams

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -27,6 +27,11 @@ export interface RestfulReactProviderProps<T = any> {
    * to deal with your retry locally instead of in the provider scope.
    */
   onError?: (err: any, retry: () => Promise<T | null>, response?: Response) => void;
+  /**
+   * Any global level query params?
+   * **Warning:** it's probably not a good idea to put API keys here. Consider headers instead.
+   */
+  queryParams?: { [key: string]: any };
 }
 
 export const Context = React.createContext<Required<RestfulReactProviderProps>>({
@@ -35,6 +40,7 @@ export const Context = React.createContext<Required<RestfulReactProviderProps>>(
   resolve: (data: any) => data,
   requestOptions: {},
   onError: noop,
+  queryParams: {},
 });
 
 export interface InjectedProps {
@@ -51,6 +57,7 @@ export default class RestfulReactProvider<T> extends React.Component<RestfulReac
           resolve: (data: any) => data,
           requestOptions: {},
           parentPath: "",
+          queryParams: value.queryParams || {},
           ...value,
         }}
       >

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -1059,5 +1059,67 @@ describe("Get", () => {
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
+    it("should inherit provider's queryParams if none specified", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({
+          myParam: true,
+        })
+        .reply(200);
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider queryParams={{ myParam: true }} base="https://my-awesome-api.fake">
+          <Get<void, void, { myParam: boolean }> path="">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+    });
+    it("should override provider's queryParams if own specified", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({
+          myParam: false,
+        })
+        .reply(200);
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider queryParams={{ myParam: true }} base="https://my-awesome-api.fake">
+          <Get<void, void, { myParam: boolean }> path="" queryParams={{ myParam: false }}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+    });
+    it("should merge provider's queryParams with own", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .query({
+          myParam: false,
+          otherParam: true,
+        })
+        .reply(200);
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider queryParams={{ otherParam: true }} base="https://my-awesome-api.fake">
+          <Get<void, void, { myParam: boolean }> path="" queryParams={{ myParam: false }}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+    });
   });
 });

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -246,7 +246,9 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
       } else {
         url = composeUrl(base!, parentPath!, requestPath || path || "");
       }
-      if (Object.keys(this.props.queryParams).length) {
+
+      // We use ! because it's in defaultProps
+      if (Object.keys(this.props.queryParams!).length) {
         url += `?${qs.stringify(this.props.queryParams)}`;
       }
       return url;

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -175,6 +175,7 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
     base: "",
     parentPath: "",
     resolve: (unresolvedData: any) => unresolvedData,
+    queryParams: {},
   };
 
   public componentDidMount() {
@@ -245,7 +246,7 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
       } else {
         url = composeUrl(base!, parentPath!, requestPath || path || "");
       }
-      if (this.props.queryParams) {
+      if (Object.keys(this.props.queryParams).length) {
         url += `?${qs.stringify(this.props.queryParams)}`;
       }
       return url;
@@ -335,7 +336,12 @@ function Get<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
     <RestfulReactConsumer>
       {contextProps => (
         <RestfulReactProvider {...contextProps} parentPath={composePath(contextProps.parentPath, props.path)}>
-          <ContextlessGet {...contextProps} {...props} __internal_hasExplicitBase={Boolean(props.base)} />
+          <ContextlessGet
+            {...contextProps}
+            {...props}
+            queryParams={{ ...contextProps.queryParams, ...props.queryParams }}
+            __internal_hasExplicitBase={Boolean(props.base)}
+          />
         </RestfulReactProvider>
       )}
     </RestfulReactConsumer>

--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -495,7 +495,7 @@ describe("Mutate", () => {
       expect(children.mock.calls[2][1].loading).toEqual(false);
     });
   });
-  describe("Compose paths and urls", () => {
+  describe("Compose paths, urls, and query parameters", () => {
     it("should compose absolute urls", async () => {
       nock("https://my-awesome-api.fake")
         .post("/absolute")
@@ -780,6 +780,109 @@ describe("Mutate", () => {
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Mutate<void, void, { myParam: boolean }> verb="POST" path="" queryParams={{ myParam: true }}>
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // post action
+      children.mock.calls[0][0]();
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after post state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+    it("should inherit provider's query params if present", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .query({
+          myParam: true,
+        })
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" queryParams={{ myParam: true }}>
+          <Mutate<void, void, { myParam: boolean }> verb="POST" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // post action
+      children.mock.calls[0][0]();
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after post state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+    it("should override provider's query params if own present", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .query({
+          myParam: false,
+        })
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" queryParams={{ myParam: true }}>
+          <Mutate<void, void, { myParam: boolean }> verb="POST" path="" queryParams={{ myParam: false }}>
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // post action
+      children.mock.calls[0][0]();
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after post state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+    it("should merge provider's query params with own if present", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .query({
+          myParam: false,
+          otherParam: true,
+        })
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" queryParams={{ otherParam: true }}>
+          <Mutate<void, void, { myParam: boolean }> verb="POST" path="" queryParams={{ myParam: false }}>
             {children}
           </Mutate>
         </RestfulProvider>,

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -113,6 +113,7 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
     base: "",
     parentPath: "",
     path: "",
+    queryParams: {},
   };
 
   /**
@@ -149,7 +150,7 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
             ? composeUrl(base!, parentPath!, composePath(path!, body))
             : composeUrl(base!, parentPath!, path!);
       }
-      if (this.props.queryParams) {
+      if (Object.keys(this.props.queryParams).length) {
         url += `?${qs.stringify(this.props.queryParams)}`;
       }
       return url;
@@ -252,6 +253,7 @@ function Mutate<TData = any, TError = any, TQueryParams = { [key: string]: any }
           <ContextlessMutate<TData, TError, TQueryParams, TRequestBody>
             {...contextProps}
             {...props}
+            queryParams={{ ...contextProps.queryParams, ...props.queryParams }}
             __internal_hasExplicitBase={Boolean(props.base)}
           />
         </RestfulReactProvider>

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -150,7 +150,9 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
             ? composeUrl(base!, parentPath!, composePath(path!, body))
             : composeUrl(base!, parentPath!, path!);
       }
-      if (Object.keys(this.props.queryParams).length) {
+
+      // We use ! because it's in defaultProps
+      if (Object.keys(this.props.queryParams!).length) {
         url += `?${qs.stringify(this.props.queryParams)}`;
       }
       return url;
@@ -253,7 +255,7 @@ function Mutate<TData = any, TError = any, TQueryParams = { [key: string]: any }
           <ContextlessMutate<TData, TError, TQueryParams, TRequestBody>
             {...contextProps}
             {...props}
-            queryParams={{ ...contextProps.queryParams, ...props.queryParams }}
+            queryParams={{ ...contextProps.queryParams, ...props.queryParams } as TQueryParams}
             __internal_hasExplicitBase={Boolean(props.base)}
           />
         </RestfulReactProvider>

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -174,6 +174,7 @@ class ContextlessPoll<TData, TError, TQueryParams> extends React.Component<
     wait: 60,
     base: "",
     resolve: (data: any) => data,
+    queryParams: {},
   };
 
   private keepPolling = !this.props.lazy;
@@ -221,7 +222,7 @@ class ContextlessPoll<TData, TError, TQueryParams> extends React.Component<
     const requestOptions = this.getRequestOptions();
 
     let url = composeUrl(base!, "", path);
-    if (this.props.queryParams) {
+    if (Object.keys(this.props.queryParams).length) {
       url += `?${qs.stringify(this.props.queryParams)}`;
     }
 
@@ -352,6 +353,7 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
           <ContextlessPoll
             {...contextProps}
             {...props}
+            queryParams={{ ...contextProps.queryParams, ...props.queryParams }}
             requestOptions={merge(contextRequestOptions, propsRequestOptions)}
           />
         );

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -222,7 +222,9 @@ class ContextlessPoll<TData, TError, TQueryParams> extends React.Component<
     const requestOptions = this.getRequestOptions();
 
     let url = composeUrl(base!, "", path);
-    if (Object.keys(this.props.queryParams).length) {
+
+    // We use a ! because it's in defaultProps
+    if (Object.keys(this.props.queryParams!).length) {
       url += `?${qs.stringify(this.props.queryParams)}`;
     }
 

--- a/src/useMutate.tsx
+++ b/src/useMutate.tsx
@@ -51,7 +51,7 @@ export function useMutate<
     typeof arguments[0] === "object" ? arguments[0] : { ...arguments[2], path: arguments[1], verb: arguments[0] };
 
   const context = useContext(Context);
-  const { verb, base = context.base, path, queryParams, resolve } = props;
+  const { verb, base = context.base, path, queryParams = {}, resolve } = props;
   const isDelete = verb === "DELETE";
 
   const [state, setState] = useState<MutateState<TData, TError>>({
@@ -95,7 +95,7 @@ export function useMutate<
       }
 
       const request = new Request(
-        resolvePath(base, isDelete ? `${path}/${body}` : path, queryParams),
+        resolvePath(base, isDelete ? `${path}/${body}` : path, { ...context.queryParams, ...queryParams }),
         merge({}, contextRequestOptions, options, propsRequestOptions, mutateRequestOptions, { signal }),
       );
 


### PR DESCRIPTION
# Why
In some cases, we'd like query params to be inherited by all hooks/components under a given provider. This PR makes this possible.