### PR TITLE
Fix: Path resolution when base path is null/empty

### DIFF
--- a/src/util/composeUrl.ts
+++ b/src/util/composeUrl.ts
@@ -2,6 +2,11 @@ import url from "url";
 
 export const composeUrl = (base: string = "", parentPath: string = "", path: string = ""): string => {
   const composedPath = composePath(parentPath, path);
+  /* If the base is empty, preceding slash will be trimmed during composition */
+  if (base === "" && composedPath.startsWith("/")) {
+    return composedPath;
+  }
+
   /* If the base contains a trailing slash, it will be trimmed during composition */
   return base!.endsWith("/") ? `${base!.slice(0, -1)}${composedPath}` : `${base}${composedPath}`;
 };


### PR DESCRIPTION
# Why
Fixes #159 and partially #93.
Get Component does not resolve the path properly when the base prop is not provided. It returns the path with a preceding slash. 
This is not the case in useGet as useGet uses a different resolvePath function in `useGet.tsx`, while Get component uses `composePath` & `composeUrl`.

Tests: No additional tests were written and all tests are passing.
