### PR TITLE
Add: Getting started with react native and editable example on expo

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,33 +7,33 @@ As an abstraction, this tool allows for greater consistency and maintainability 
 <!-- START doctoc generated TOC please keep comment here to allow auto update -->
 <!-- DON'T EDIT THIS SECTION, INSTEAD RE-RUN doctoc TO UPDATE -->
 
-- [Overview](#overview)
-- [Getting Started](#getting-started)
-- [Features](#features)
-  - [Global Configuration](#global-configuration)
-    - [`RestfulProvider` API](#restfulprovider-api)
-  - [Composability](#composability)
-    - [Full `Get` Component API](#full-get-component-api)
-  - [Loading and Error States](#loading-and-error-states)
-  - [Lazy Fetching](#lazy-fetching)
-  - [Response Resolution](#response-resolution)
-  - [Debouncing Requests](#debouncing-requests)
-  - [TypeScript Integration](#typescript-integration)
-  - [Query Parameters](#query-parameters)
-  - [Mutations with `Mutate`](#mutations-with-mutate)
-    - [Full `Mutate` Component API](#full-mutate-component-api)
-  - [Polling with `Poll`](#polling-with-poll)
-    - [Long Polling](#long-polling)
-    - [Full `Poll` Component API](#full-poll-component-api)
-  - [Code Generation](#code-generation)
-    - [Usage](#usage)
-    - [Import from GitHub](#import-from-github)
-    - [Transforming an Original Spec](#transforming-an-original-spec)
-  - [Caching](#caching)
-- [Contributing](#contributing)
-  - [Code](#code)
-  - [Dogfooding](#dogfooding)
-- [Next Steps](#next-steps)
+- [`restful-react`](#restful-react)
+  - [Overview](#overview)
+  - [Getting Started](#getting-started)
+  - [Features](#features)
+    - [Global Configuration](#global-configuration)
+      - [`RestfulProvider` API](#restfulprovider-api)
+    - [Loading and Error States](#loading-and-error-states)
+    - [Lazy Fetching](#lazy-fetching)
+    - [Response Resolution](#response-resolution)
+    - [Debouncing Requests](#debouncing-requests)
+    - [TypeScript Integration](#typescript-integration)
+    - [Query Parameters](#query-parameters)
+    - [Mutations with `useMutate`](#mutations-with-usemutate)
+    - [Polling with `Poll`](#polling-with-poll)
+      - [Long Polling](#long-polling)
+      - [Full `Poll` Component API](#full-poll-component-api)
+    - [Code Generation](#code-generation)
+      - [Usage](#usage)
+      - [Validation of the OpenAPI specification](#validation-of-the-openapi-specification)
+      - [Import from GitHub](#import-from-github)
+      - [Transforming an Original Spec](#transforming-an-original-spec)
+      - [Advanced configuration](#advanced-configuration)
+        - [Config File Format](#config-file-format)
+        - [Config File Example](#config-file-example)
+  - [Contributing](#contributing)
+    - [Code](#code)
+  - [Next Steps](#next-steps)
 
 <!-- END doctoc generated TOC please keep comment here to allow auto update -->
 
@@ -56,6 +56,36 @@ const MyComponent = () => {
 };
 
 export default MyComponent;
+```
+
+and on React Native,
+[Edit restful-react basic demo on Expo](https://snack.expo.io/SJaSAj49r)
+
+```jsx
+import { AppRegistry, Image } from "react-native";
+import React from "react";
+
+import { useGet } from "restful-react";
+
+const App = () => {
+  const { data: randomDogImage } = useGet({
+    path: "https://dog.ceo/api/breeds/image/random",
+  });
+  return (
+    <>
+      {randomDogImage && (
+        <Image
+          style={{ width: 250, height: 250 }}
+          source={{
+            uri: randomDogImage.message,
+          }}
+        />
+      )}
+    </>
+  );
+};
+
+AppRegistry.registerComponent("react-native-app", () => App);
 ```
 
 ## Getting Started

--- a/package.json
+++ b/package.json
@@ -77,6 +77,7 @@
     "npm-run-all": "^4.1.5",
     "prettier": "^1.16.4",
     "react-dom": "^16.8.5",
+    "react": "^16.8.5",
     "react-hooks-testing-library": "^0.5.0",
     "react-test-renderer": "^16.8.6",
     "react-testing-library": "^7.0.0",
@@ -97,7 +98,6 @@
     "lodash": "^4.17.11",
     "openapi3-ts": "^0.12.0",
     "qs": "^6.6.0",
-    "react": "^16.8.4",
     "react-fast-compare": "^2.0.4",
     "request": "^2.88.0",
     "swagger2openapi": "^3.2.14",
@@ -105,6 +105,6 @@
     "yamljs": "^0.3.0"
   },
   "peerDependencies": {
-    "react": "^16.8.4"
+    "react": ">=16.8.5"
   }
 }

--- a/yarn.lock
+++ b/yarn.lock
@@ -7575,15 +7575,14 @@ react-testing-library@^7.0.0:
     "@babel/runtime" "^7.4.3"
     dom-testing-library "^4.0.0"
 
-react@^16.8.4:
-  version "16.8.5"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.8.5.tgz#49be3b655489d74504ad994016407e8a0445de66"
-  integrity sha512-daCb9TD6FZGvJ3sg8da1tRAtIuw29PbKZW++NN4wqkbEvxL+bZpaaYb4xuftW/SpXmgacf1skXl/ddX6CdOlDw==
+react@^16.8.5:
+  version "16.11.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.11.0.tgz#d294545fe62299ccee83363599bf904e4a07fdbb"
+  integrity sha512-M5Y8yITaLmU0ynd0r1Yvfq98Rmll6q8AxaEe88c8e7LxO8fZ2cNgmFt0aGAS9wzf1Ao32NKXtCl+/tVVtkxq6g==
   dependencies:
     loose-envify "^1.1.0"
     object-assign "^4.1.1"
     prop-types "^15.6.2"
-    scheduler "^0.13.5"
 
 read-pkg-up@^4.0.0:
   version "4.0.0"


### PR DESCRIPTION
# Why
Fixes #93 
Added: Getting started with react native and editable example on the expo. Bumped react version to 16.8.5 from 16.8.4 to match react-dom dependency and added react to dev dependency, so it won't have any usage conflicts