### PR TITLE
Update React peer dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -104,5 +104,8 @@
     "swagger2openapi": "^3.2.14",
     "url": "^0.11.0",
     "yamljs": "^0.3.0"
+  },	
+  "peerDependencies": {	
+    "react": "^16.8.5"
   }
-}
+} 

--- a/package.json
+++ b/package.json
@@ -104,8 +104,5 @@
     "swagger2openapi": "^3.2.14",
     "url": "^0.11.0",
     "yamljs": "^0.3.0"
-  },
-  "peerDependencies": {
-    "react": ">=16.8.5"
   }
 }


### PR DESCRIPTION
# Why
This addresses issue here https://github.com/contiamo/restful-react/issues/181, this will ensure that future react native versions are supported and no longer installs multiple React versions, but unsure if this will have other implications
