### PR TITLE
#180: Promised request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ All contributions are welcome – especially:
 
 ### Code
 
-If you'd like to actively develop or help maintain this project, clone the repo and then `yarn watch` to get into dev mode. There are existing tests against which you can test the library. Typically, this looks like
+If you'd like to actively develop or help maintain this project then there are existing tests against which you can test the library with. Typically, this looks like
 
 - `git clone git@github.com:contiamo/restful-react.git`
 - `cd restful-react`

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -18,7 +18,7 @@ export interface RestfulReactProviderProps<T = any> {
   /**
    * Options passed to the fetch request.
    */
-  requestOptions?: (() => Partial<RequestInit>) | Partial<RequestInit>;
+  requestOptions?: Partial<RequestInit> | (() => Partial<RequestInit>) | (() => Promise<Partial<RequestInit>>);
   /**
    * Trigger on each error.
    * For `Get` and `Mutation` calls, you can also call `retry` to retry the exact same request.

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -565,6 +565,27 @@ describe("Get", () => {
       expect(children.mock.calls[1][1].loading).toEqual(false);
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
+
+    it("should add a promised custom header with the requestOptions method", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get path="" requestOptions={() => new Promise(res => res({ headers: { foo: "bar" } }))}>
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
   });
 
   describe("actions", () => {

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -204,7 +204,7 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
     this.abortController.abort();
   }
 
-  public getRequestOptions = (
+  public getRequestOptions = async (
     extraOptions?: Partial<RequestInit>,
     extraHeaders?: boolean | { [key: string]: string },
   ) => {
@@ -213,11 +213,11 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
     if (typeof requestOptions === "function") {
       return {
         ...extraOptions,
-        ...requestOptions(),
+        ...(await requestOptions()),
         headers: new Headers({
           ...(typeof extraHeaders !== "boolean" ? extraHeaders : {}),
           ...(extraOptions || {}).headers,
-          ...(requestOptions() || {}).headers,
+          ...((await requestOptions()) || {}).headers,
         }),
       };
     }
@@ -254,7 +254,7 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
       return url;
     };
 
-    const request = new Request(makeRequestPath(), this.getRequestOptions(thisRequestOptions));
+    const request = new Request(makeRequestPath(), await this.getRequestOptions(thisRequestOptions));
     try {
       const response = await fetch(request, { signal: this.signal });
       const { data, responseError } = await processResponse(response);

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -786,6 +786,27 @@ describe("Poll", () => {
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
 
+    it("should add a promised custom header with the requestOptions method", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Poll path="" requestOptions={() => new Promise(res => res({ headers: { foo: "bar" } }))}>
+            {children}
+          </Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+
     it("should merge headers with providers", async () => {
       nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar", baz: "qux" } })
         .get("/")

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -358,7 +358,7 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
             {...contextProps}
             {...props}
             queryParams={{ ...contextProps.queryParams, ...props.queryParams }}
-            requestOptions={merge(contextRequestOptions, propsRequestOptions)}
+            requestOptions={async () => merge(contextRequestOptions, propsRequestOptions)}
           />
         );
       }}

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -195,8 +195,10 @@ class ContextlessPoll<TData, TError, TQueryParams> extends React.Component<
     return true;
   };
 
-  private getRequestOptions = () =>
-    typeof this.props.requestOptions === "function" ? this.props.requestOptions() : this.props.requestOptions || {};
+  private getRequestOptions = async () =>
+    typeof this.props.requestOptions === "function"
+      ? await this.props.requestOptions()
+      : this.props.requestOptions || {};
 
   // 304 is not a OK status code but is green in Chrome 🤦🏾‍♂️
   private isResponseOk = (response: Response) => response.ok || response.status === 304;
@@ -219,7 +221,7 @@ class ContextlessPoll<TData, TError, TQueryParams> extends React.Component<
     // If we should keep going,
     const { base, path, interval, wait } = this.props;
     const { lastPollIndex } = this.state;
-    const requestOptions = this.getRequestOptions();
+    const requestOptions = await this.getRequestOptions();
 
     let url = composeUrl(base!, "", path);
 


### PR DESCRIPTION
# Why

Allows promised request options to be provided to components and hooks.

See #180 for more detail