### PR TITLE
[WIP] Memoize refetch in useGet hook

### DIFF
--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -194,11 +194,11 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
 
   const abortController = useRef(new AbortController());
 
-  // refetch function  with the same dependency array as the fetchData deep effect
+  // combine refetch options defined at the component level to the fetchData request
   const refetch = (options: RefetchOptions<TData, TQueryParams> = {}) =>
     fetchData({ ...props, ...options }, state, setState, context, abortController);
 
-  // Memoise refetch
+  // Memoise refetch to ensure referential equality
   const refetchMemo = useCallback((options: RefetchOptions<TData, TQueryParams> = {}) => refetch(options), []);
 
   useDeepCompareEffect(() => {

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -194,6 +194,13 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
 
   const abortController = useRef(new AbortController());
 
+  // refetch function  with the same dependency array as the fetchData deep effect
+  const refetch = (options: RefetchOptions<TData, TQueryParams> = {}) =>
+    fetchData({ ...props, ...options }, state, setState, context, abortController);
+
+  // Memoise refetch
+  const refetchMemo = useCallback((options: RefetchOptions<TData, TQueryParams> = {}) => refetch(options), []);
+
   useDeepCompareEffect(() => {
     if (!props.lazy) {
       fetchData(props, state, setState, context, abortController);
@@ -219,7 +226,6 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
       abortController.current.abort();
       abortController.current = new AbortController();
     },
-    refetch: (options: RefetchOptions<TData, TQueryParams> = {}) =>
-      fetchData({ ...props, ...options }, state, setState, context, abortController),
+    refetch: refetchMemo,
   };
 }


### PR DESCRIPTION
# Why

Addresses https://github.com/contiamo/restful-react/issues/186, refetch is memoized against the same dependency array as the auto `fetchData()` effect within the package. 
