### PR TITLE
feat: set RestfulProviderContext as displayName for Context component

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -48,6 +48,8 @@ export interface InjectedProps {
 }
 
 export default class RestfulReactProvider<T> extends React.Component<RestfulReactProviderProps<T>> {
+  static displayName = "RestfulProviderContext";
+
   public render() {
     const { children, ...value } = this.props;
     return (


### PR DESCRIPTION
# Why

Add capabilities to display the name of the Provider and the Consumer as per #107 