### PR TITLE
Promise request options

### DIFF
--- a/README.md
+++ b/README.md
@@ -683,7 +683,7 @@ All contributions are welcome – especially:
 
 ### Code
 
-If you'd like to actively develop or help maintain this project, clone the repo and then `yarn watch` to get into dev mode. There are existing tests against which you can test the library. Typically, this looks like
+If you'd like to actively develop or help maintain this project then there are existing tests against which you can test the library with. Typically, this looks like
 
 - `git clone git@github.com:contiamo/restful-react.git`
 - `cd restful-react`

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -18,7 +18,7 @@ export interface RestfulReactProviderProps<T = any> {
   /**
    * Options passed to the fetch request.
    */
-  requestOptions?: (() => Partial<RequestInit>) | Partial<RequestInit>;
+  requestOptions?: (() => Partial<RequestInit> | Promise<Partial<RequestInit>>) | Partial<RequestInit>;
   /**
    * Trigger on each error.
    * For `Get` and `Mutation` calls, you can also call `retry` to retry the exact same request.
@@ -48,7 +48,7 @@ export interface InjectedProps {
 }
 
 export default class RestfulReactProvider<T> extends React.Component<RestfulReactProviderProps<T>> {
-  static displayName = "RestfulProviderContext";
+  public static displayName = "RestfulProviderContext";
 
   public render() {
     const { children, ...value } = this.props;

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -566,6 +566,30 @@ describe("Get", () => {
       expect(children.mock.calls[1][1].loading).toEqual(false);
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
+
+    it("should add a promised custom header with the requestOptions method", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Get
+            path=""
+            requestOptions={() => new Promise(res => setTimeout(() => res({ headers: { foo: "bar" } }), 1000))}
+          >
+            {children}
+          </Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
   });
 
   describe("actions", () => {

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -660,7 +660,7 @@ describe("Get", () => {
     });
   });
   describe("refetch after update", () => {
-    it("should not refetch when base, path or resolve don't change", () => {
+    it("should not refetch when base, path or resolve don't change", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
         .get("/")
@@ -678,7 +678,7 @@ describe("Get", () => {
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
-      expect(apiCalls).toEqual(1);
+      await wait(() => expect(apiCalls).toEqual(1));
     });
 
     it("should rewrite the base and handle path accordingly", async () => {

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -13,6 +13,7 @@ describe("Get", () => {
     cleanup();
     nock.cleanAll();
   });
+
   describe("classic usage", () => {
     it("should call the url set in provider", async () => {
       nock("https://my-awesome-api.fake")
@@ -635,6 +636,7 @@ describe("Get", () => {
       );
       await wait(() => expect(apiCalls).toEqual(1));
     });
+
     it("should call the API only 10 times without debounce", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
@@ -642,13 +644,16 @@ describe("Get", () => {
         .get("/?test=XXX")
         .reply(200, () => ++apiCalls)
         .persist();
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="?test=1">{children}</Get>
         </RestfulProvider>,
       );
+
       times(10, i =>
         rerender(
           <RestfulProvider base="https://my-awesome-api.fake">
@@ -656,9 +661,11 @@ describe("Get", () => {
           </RestfulProvider>,
         ),
       );
-      expect(apiCalls).toEqual(10);
+
+      await wait(() => expect(apiCalls).toEqual(10));
     });
   });
+
   describe("refetch after update", () => {
     it("should not refetch when base, path or resolve don't change", async () => {
       let apiCalls = 0;
@@ -666,18 +673,22 @@ describe("Get", () => {
         .get("/")
         .reply(200, () => ++apiCalls)
         .persist();
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake" resolve={data => data}>
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
+
       rerender(
         <RestfulProvider base="https://my-awesome-api.fake" resolve={data => data}>
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(apiCalls).toEqual(1));
     });
 
@@ -685,7 +696,6 @@ describe("Get", () => {
       nock("https://my-other-api.fake")
         .get("/")
         .reply(200, { id: 1 });
-
       nock("https://my-awesome-api.fake/eaegae")
         .post("/LOL")
         .reply(200, { id: 1 });
@@ -707,21 +717,26 @@ describe("Get", () => {
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
-    it("should refetch when base changes", () => {
+
+    it("should refetch when base changes", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
         .get("/")
         .reply(200, () => ++apiCalls);
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
+
       nock("https://my-new-api.fake")
         .get("/")
         .reply(200, () => ++apiCalls);
+
       rerender(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get base="https://my-new-api.fake" path="">
@@ -729,44 +744,55 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
-      expect(apiCalls).toEqual(2);
+
+      await wait(() => expect(apiCalls).toEqual(2));
     });
-    it("should refetch when path changes", () => {
+
+    it("should refetch when path changes", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
         .filteringPath(/test=[^&]*/g, "test=XXX")
         .get("/?test=XXX")
         .reply(200, () => ++apiCalls)
         .persist();
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/?test=0">{children}</Get>
         </RestfulProvider>,
       );
+
       rerender(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/?test=1">{children}</Get>
         </RestfulProvider>,
       );
-      expect(apiCalls).toEqual(2);
+
+      await wait(() => expect(apiCalls).toEqual(2));
     });
-    it("should refetch when resolve changes", () => {
+
+    it("should refetch when resolve changes", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
         .get("/")
         .reply(200, () => ++apiCalls)
         .persist();
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
       const providerResolve = a => a;
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake" resolve={providerResolve}>
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
+
       const newResolve = () => "hello";
+
       rerender(
         <RestfulProvider base="https://my-awesome-api.fake" resolve={newResolve}>
           <Get path="" resolve={newResolve}>
@@ -774,17 +800,21 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
-      expect(apiCalls).toEqual(2);
+
+      await wait(() => expect(apiCalls).toEqual(2));
     });
-    it("should NOT refetch when queryParams are the same", () => {
+
+    it("should NOT refetch when queryParams are the same", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
         .get("/")
         .query({ page: 2 })
         .reply(200, () => ++apiCalls)
         .persist();
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="" queryParams={{ page: 2 }}>
@@ -792,6 +822,7 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
+
       rerender(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="" queryParams={{ page: 2 }}>
@@ -799,9 +830,11 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
-      expect(apiCalls).toEqual(1);
+
+      await wait(() => expect(apiCalls).toEqual(1));
     });
-    it("should refetch when queryParams changes", () => {
+
+    it("should refetch when queryParams changes", async () => {
       let apiCalls = 0;
       nock("https://my-awesome-api.fake")
         .get("/")
@@ -812,13 +845,16 @@ describe("Get", () => {
         .query({ page: 2 })
         .reply(200, () => ++apiCalls)
         .persist();
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       const { rerender } = render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="">{children}</Get>
         </RestfulProvider>,
       );
+
       rerender(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="" queryParams={{ page: 2 }}>
@@ -826,23 +862,29 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
-      expect(apiCalls).toEqual(2);
+
+      await wait(() => expect(apiCalls).toEqual(2));
     });
   });
+
   describe("Compose paths and urls", () => {
     it("should compose the url with the base", async () => {
       nock("https://my-awesome-api.fake")
         .get("/plop")
         .reply(200);
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/plop">{children}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
+
     it("should compose absolute urls", async () => {
       nock("https://my-awesome-api.fake")
         .get("/people")
@@ -850,15 +892,19 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake")
         .get("/absolute")
         .reply(200);
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/people">{() => <Get path="/absolute">{children}</Get>}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(3));
     });
+
     it("should compose relative urls", async () => {
       nock("https://my-awesome-api.fake")
         .get("/people")
@@ -866,16 +912,20 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake")
         .get("/people/relative")
         .reply(200, { path: "/people/relative" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake">
           <Get path="/people">{() => <Get path="relative">{children}</Get>}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(3));
       expect(children.mock.calls[2][0]).toEqual({ path: "/people/relative" });
     });
+
     it("should compose absolute urls with base subpath", async () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/people")
@@ -883,16 +933,20 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/absolute")
         .reply(200, { path: "/absolute" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake/MY_SUBROUTE">
           <Get path="/people">{() => <Get path="/absolute">{children}</Get>}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(3));
       expect(children.mock.calls[2][0]).toEqual({ path: "/absolute" });
     });
+
     it("should compose relative urls with base subpath", async () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/people")
@@ -900,6 +954,7 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/people/relative")
         .reply(200, { path: "/people/relative" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
       render(
@@ -907,9 +962,11 @@ describe("Get", () => {
           <Get path="/people">{() => <Get path="relative">{children}</Get>}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(3));
       expect(children.mock.calls[2][0]).toEqual({ path: "/people/relative" });
     });
+
     it("should compose properly when base contains a trailing slash", async () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/people")
@@ -917,16 +974,20 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/people/relative")
         .reply(200, { path: "/people/relative" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake/MY_SUBROUTE/">
           <Get path="/people">{() => <Get path="relative">{children}</Get>}</Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(3));
       expect(children.mock.calls[2][0]).toEqual({ path: "/people/relative" });
     });
+
     it("should compose more nested absolute and relative urls", async () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/absolute-1")
@@ -943,8 +1004,10 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake/MY_SUBROUTE")
         .get("/absolute-2/relative-2/relative-3")
         .reply(200, { path: "/absolute-2/relative-2/relative-3" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake/MY_SUBROUTE/">
           <Get path="/absolute-1">
@@ -960,9 +1023,11 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(6));
       expect(children.mock.calls[5][0]).toEqual({ path: "/absolute-2/relative-2/relative-3" });
     });
+
     it("should compose properly when one of the paths is empty string", async () => {
       nock("https://my-awesome-api.fake")
         .get("/absolute-1")
@@ -979,8 +1044,10 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake")
         .get("/absolute-1/absolute-2/relative-2/relative-3")
         .reply(200, { path: "/absolute-1/absolute-2/relative-2/relative-3" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake/absolute-1">
           <Get path="">
@@ -996,9 +1063,11 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(6));
       expect(children.mock.calls[5][0]).toEqual({ path: "/absolute-1/absolute-2/relative-2/relative-3" });
     });
+
     it("should compose properly when one of the paths is lone slash and base has trailing slash", async () => {
       nock("https://my-awesome-api.fake")
         .get("/absolute-1")
@@ -1015,8 +1084,10 @@ describe("Get", () => {
       nock("https://my-awesome-api.fake")
         .get("/absolute-1/absolute-2/relative-2/relative-3")
         .reply(200, { path: "/absolute-1/absolute-2/relative-2/relative-3" });
+
       const children = jest.fn();
       children.mockReturnValue(<div />);
+
       render(
         <RestfulProvider base="https://my-awesome-api.fake/absolute-1/">
           <Get path="/">
@@ -1032,6 +1103,7 @@ describe("Get", () => {
           </Get>
         </RestfulProvider>,
       );
+
       await wait(() => expect(children.mock.calls.length).toBe(6));
       expect(children.mock.calls[5][0]).toEqual({ path: "/absolute-1/absolute-2/relative-2/relative-3" });
     });
@@ -1059,6 +1131,7 @@ describe("Get", () => {
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
+
     it("should inherit provider's queryParams if none specified", async () => {
       nock("https://my-awesome-api.fake")
         .get("/")
@@ -1078,6 +1151,7 @@ describe("Get", () => {
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
+
     it("should override provider's queryParams if own specified", async () => {
       nock("https://my-awesome-api.fake")
         .get("/")
@@ -1099,6 +1173,7 @@ describe("Get", () => {
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
+
     it("should merge provider's queryParams with own", async () => {
       nock("https://my-awesome-api.fake")
         .get("/")

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -204,20 +204,21 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
     this.abortController.abort();
   }
 
-  public getRequestOptions = (
+  public getRequestOptions = async (
     extraOptions?: Partial<RequestInit>,
     extraHeaders?: boolean | { [key: string]: string },
   ) => {
     const { requestOptions } = this.props;
 
     if (typeof requestOptions === "function") {
+      const options = (await requestOptions()) || {};
       return {
         ...extraOptions,
-        ...requestOptions(),
+        ...options,
         headers: new Headers({
           ...(typeof extraHeaders !== "boolean" ? extraHeaders : {}),
           ...(extraOptions || {}).headers,
-          ...(requestOptions() || {}).headers,
+          ...options.headers,
         }),
       };
     }
@@ -254,7 +255,7 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
       return url;
     };
 
-    const request = new Request(makeRequestPath(), this.getRequestOptions(thisRequestOptions));
+    const request = new Request(makeRequestPath(), await this.getRequestOptions(thisRequestOptions));
     try {
       const response = await fetch(request, { signal: this.signal });
       const { data, responseError } = await processResponse(response);

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -166,7 +166,7 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
       headers: {
         "content-type": typeof body === "object" ? "application/json" : "text/plain",
         ...(typeof providerRequestOptions === "function"
-          ? providerRequestOptions().headers
+          ? (await providerRequestOptions()).headers
           : (providerRequestOptions || {}).headers),
         ...(mutateRequestOptions ? mutateRequestOptions.headers : {}),
       },

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -11,6 +11,7 @@ describe("Poll", () => {
     cleanup();
     nock.cleanAll();
   });
+
   describe("classic usage", () => {
     it("should call the url set in provider", async () => {
       nock("https://my-awesome-api.fake", {

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -787,6 +787,30 @@ describe("Poll", () => {
       expect(children.mock.calls[1][0]).toEqual({ id: 1 });
     });
 
+    it("should add a promised custom header with the requestOptions method", async () => {
+      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar" } })
+        .get("/")
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Poll
+            path=""
+            requestOptions={() => new Promise(res => setTimeout(() => res({ headers: { foo: "bar" } }), 1000))}
+          >
+            {children}
+          </Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(children.mock.calls[1][1].loading).toEqual(false);
+      expect(children.mock.calls[1][0]).toEqual({ id: 1 });
+    });
+
     it("should merge headers with providers", async () => {
       nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar", baz: "qux" } })
         .get("/")

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -219,7 +219,7 @@ class ContextlessPoll<TData, TError, TQueryParams> extends React.Component<
     // If we should keep going,
     const { base, path, interval, wait } = this.props;
     const { lastPollIndex } = this.state;
-    const requestOptions = this.getRequestOptions();
+    const requestOptions = await this.getRequestOptions();
 
     let url = composeUrl(base!, "", path);
 
@@ -343,13 +343,13 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
   // Compose Contexts to allow for URL nesting
   return (
     <RestfulReactConsumer>
-      {contextProps => {
+      {async contextProps => {
         const contextRequestOptions =
           typeof contextProps.requestOptions === "function"
             ? contextProps.requestOptions()
             : contextProps.requestOptions || {};
         const propsRequestOptions =
-          typeof props.requestOptions === "function" ? props.requestOptions() : props.requestOptions || {};
+          typeof props.requestOptions === "function" ? await props.requestOptions() : props.requestOptions || {};
 
         return (
           <ContextlessPoll

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -343,20 +343,20 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
   // Compose Contexts to allow for URL nesting
   return (
     <RestfulReactConsumer>
-      {async contextProps => {
+      {contextProps => {
         const contextRequestOptions =
           typeof contextProps.requestOptions === "function"
-            ? await contextProps.requestOptions()
+            ? contextProps.requestOptions()
             : contextProps.requestOptions || {};
         const propsRequestOptions =
-          typeof props.requestOptions === "function" ? await props.requestOptions() : props.requestOptions || {};
+          typeof props.requestOptions === "function" ? props.requestOptions() : props.requestOptions || {};
 
         return (
           <ContextlessPoll
             {...contextProps}
             {...props}
             queryParams={{ ...contextProps.queryParams, ...props.queryParams }}
-            requestOptions={merge(contextRequestOptions, propsRequestOptions)}
+            requestOptions={async () => merge(await contextRequestOptions, await propsRequestOptions)}
           />
         );
       }}

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -346,7 +346,7 @@ function Poll<TData = any, TError = any, TQueryParams = { [key: string]: any }>(
       {async contextProps => {
         const contextRequestOptions =
           typeof contextProps.requestOptions === "function"
-            ? contextProps.requestOptions()
+            ? await contextProps.requestOptions()
             : contextProps.requestOptions || {};
         const propsRequestOptions =
           typeof props.requestOptions === "function" ? await props.requestOptions() : props.requestOptions || {};

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -87,10 +87,10 @@ async function _fetchData<TData, TError, TQueryParams>(
   }
 
   const requestOptions =
-    (typeof props.requestOptions === "function" ? props.requestOptions() : props.requestOptions) || {};
+    (typeof props.requestOptions === "function" ? await props.requestOptions() : props.requestOptions) || {};
 
   const contextRequestOptions =
-    (typeof context.requestOptions === "function" ? context.requestOptions() : context.requestOptions) || {};
+    (typeof context.requestOptions === "function" ? await context.requestOptions() : context.requestOptions) || {};
 
   const request = new Request(
     resolvePath(base, path, { ...context.queryParams, ...queryParams }),

--- a/src/useMutate.tsx
+++ b/src/useMutate.tsx
@@ -78,10 +78,10 @@ export function useMutate<
       const signal = abortController.current.signal;
 
       const propsRequestOptions =
-        (typeof props.requestOptions === "function" ? props.requestOptions() : props.requestOptions) || {};
+        (typeof props.requestOptions === "function" ? await props.requestOptions() : props.requestOptions) || {};
 
       const contextRequestOptions =
-        (typeof context.requestOptions === "function" ? context.requestOptions() : context.requestOptions) || {};
+        (typeof context.requestOptions === "function" ? await context.requestOptions() : context.requestOptions) || {};
 
       const options: RequestInit = {
         method: verb,


### PR DESCRIPTION
# Why

Second go at allowing for promised request options to be provided to components and hooks.

See #180 for more detail