### PR TITLE
Use `summary` and `description` as generated documentation

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -409,8 +409,11 @@ ${formatDescription(
     verb === "get" ? "" : ` | "verb"`
   }>${paramsInPath.length ? ` & {${paramsTypes}}` : ""};
 
-${operation.summary ? "// " + operation.summary : ""}
-export const use${componentName} = (${
+${formatDescription(
+  operation.summary && operation.description
+    ? `${operation.summary}\n\n${operation.description}`
+    : `${operation.summary || ""}${operation.description || ""}`,
+)}export const use${componentName} = (${
     paramsInPath.length ? `{${paramsInPath.join(", ")}, ...props}` : "props"
   }: Use${componentName}Props) => use${Component}<${genericsTypes}>(${
     verb === "get" ? "" : `"${verb.toUpperCase()}", `

--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -54,7 +54,13 @@ export const FindPets = (props: FindPetsProps) => (
 
 export type UseFindPetsProps = Omit<UseGetProps<Pet[], FindPetsQueryParams>, \\"path\\">;
 
-
+/**
+ * Returns all pets from the system that the user has access to
+ * Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+ * 
+ * Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+ * 
+ */
 export const useFindPets = (props: UseFindPetsProps) => useGet<Pet[], Error, FindPetsQueryParams>(\`/pets\`, props);
 
 
@@ -73,7 +79,9 @@ export const AddPet = (props: AddPetProps) => (
 
 export type UseAddPetProps = Omit<UseMutateProps<Pet, void, NewPet>, \\"path\\" | \\"verb\\">;
 
-
+/**
+ * Creates a new pet in the store.  Duplicates are allowed
+ */
 export const useAddPet = (props: UseAddPetProps) => useMutate<Pet, Error, void, NewPet>(\\"POST\\", \`/pets\`, props);
 
 
@@ -91,7 +99,9 @@ export const FindPetById = ({id, ...props}: FindPetByIdProps) => (
 
 export type UseFindPetByIdProps = Omit<UseGetProps<Pet, void>, \\"path\\"> & {id: number};
 
-
+/**
+ * Returns a user based on a single ID, if the user does not have access to the pet
+ */
 export const useFindPetById = ({id, ...props}: UseFindPetByIdProps) => useGet<Pet, Error, void>(\`/pets/\${id}\`, props);
 
 
@@ -110,7 +120,9 @@ export const DeletePet = (props: DeletePetProps) => (
 
 export type UseDeletePetProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
 
-
+/**
+ * deletes a single pet based on the ID supplied
+ */
 export const useDeletePet = (props: UseDeletePetProps) => useMutate<void, Error, void, string>(\\"DELETE\\", \`/pets\`, props);
 
 "

--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -8,23 +8,43 @@ import { Get, GetProps, useGet, UseGetProps, Mutate, MutateProps, useMutate, Use
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
-export type Pet = NewPet & {id: number};
+export type Pet = NewPet & {
+  id: number;
+};
 
-export interface NewPet {name: string; tag?: string}
+export interface NewPet {
+  name: string;
+  tag?: string;
+}
 
 export type CatOrDog = Cat | Dog;
 
-export interface Cat {type: \\"cat\\"; breed: \\"labrador\\" | \\"carlin\\" | \\"beagle\\"}
+export interface Cat {
+  type: \\"cat\\";
+  breed: \\"labrador\\" | \\"carlin\\" | \\"beagle\\";
+}
 
-export interface Dog {type: \\"dog\\"; breed: \\"saimois\\" | \\"bengal\\" | \\"british shorthair\\"}
+export interface Dog {
+  type: \\"dog\\";
+  breed: \\"saimois\\" | \\"bengal\\" | \\"british shorthair\\";
+}
 
-export interface Error {code: number; message: string}
+export interface Error {
+  code: number;
+  message: string;
+}
 
 export interface FindPetsQueryParams {tags?: string[]; limit?: number}
 
 export type FindPetsProps = Omit<GetProps<Pet[], Error, FindPetsQueryParams>, \\"path\\">;
 
-
+/**
+ * Returns all pets from the system that the user has access to
+ * Nam sed condimentum est. Maecenas tempor sagittis sapien, nec rhoncus sem sagittis sit amet. Aenean at gravida augue, ac iaculis sem. Curabitur odio lorem, ornare eget elementum nec, cursus id lectus. Duis mi turpis, pulvinar ac eros ac, tincidunt varius justo. In hac habitasse platea dictumst. Integer at adipiscing ante, a sagittis ligula. Aenean pharetra tempor ante molestie imperdiet. Vivamus id aliquam diam. Cras quis velit non tortor eleifend sagittis. Praesent at enim pharetra urna volutpat venenatis eget eget mauris. In eleifend fermentum facilisis. Praesent enim enim, gravida ac sodales sed, placerat id erat. Suspendisse lacus dolor, consectetur non augue vel, vehicula interdum libero. Morbi euismod sagittis libero sed lacinia.
+ * 
+ * Sed tempus felis lobortis leo pulvinar rutrum. Nam mattis velit nisl, eu condimentum ligula luctus nec. Phasellus semper velit eget aliquet faucibus. In a mattis elit. Phasellus vel urna viverra, condimentum lorem id, rhoncus nibh. Ut pellentesque posuere elementum. Sed a varius odio. Morbi rhoncus ligula libero, vel eleifend nunc tristique vitae. Fusce et sem dui. Aenean nec scelerisque tortor. Fusce malesuada accumsan magna vel tempus. Quisque mollis felis eu dolor tristique, sit amet auctor felis gravida. Sed libero lorem, molestie sed nisl in, accumsan tempor nisi. Fusce sollicitudin massa ut lacinia mattis. Sed vel eleifend lorem. Pellentesque vitae felis pretium, pulvinar elit eu, euismod sapien.
+ * 
+ */
 export const FindPets = (props: FindPetsProps) => (
   <Get<Pet[], Error, FindPetsQueryParams>
     path={\`/pets\`}
@@ -40,7 +60,9 @@ export const useFindPets = (props: UseFindPetsProps) => useGet<Pet[], Error, Fin
 
 export type AddPetProps = Omit<MutateProps<Pet, Error, void, NewPet>, \\"path\\" | \\"verb\\">;
 
-
+/**
+ * Creates a new pet in the store.  Duplicates are allowed
+ */
 export const AddPet = (props: AddPetProps) => (
   <Mutate<Pet, Error, void, NewPet>
     verb=\\"POST\\"
@@ -57,7 +79,9 @@ export const useAddPet = (props: UseAddPetProps) => useMutate<Pet, Error, void, 
 
 export type FindPetByIdProps = Omit<GetProps<Pet, Error, void>, \\"path\\"> & {id: number};
 
-
+/**
+ * Returns a user based on a single ID, if the user does not have access to the pet
+ */
 export const FindPetById = ({id, ...props}: FindPetByIdProps) => (
   <Get<Pet, Error, void>
     path={\`/pets/\${id}\`}
@@ -73,7 +97,9 @@ export const useFindPetById = ({id, ...props}: UseFindPetByIdProps) => useGet<Pe
 
 export type DeletePetProps = Omit<MutateProps<void, Error, void, string>, \\"path\\" | \\"verb\\">;
 
-
+/**
+ * deletes a single pet based on the ID supplied
+ */
 export const DeletePet = (props: DeletePetProps) => (
   <Mutate<void, Error, void, string>
     verb=\\"DELETE\\"

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -182,11 +182,11 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  name: string;
-                                                  age: number;
-                                                }"
-                                    `);
+                                                        "{
+                                                          name: string;
+                                                          age: number;
+                                                        }"
+                                          `);
     });
 
     it("should return the type of an object with optional values", () => {
@@ -203,11 +203,11 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  name: string;
-                                                  age?: number;
-                                                }"
-                                    `);
+                                                        "{
+                                                          name: string;
+                                                          age?: number;
+                                                        }"
+                                          `);
     });
 
     it("should deal with additionalProperties", () => {
@@ -218,36 +218,10 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  [key: string]: string;
-                                                }"
-                                    `);
-    });
-
-    it("should deal with ref additionalProperties", () => {
-      const item = {
-        type: "object",
-        additionalProperties: {
-          $ref: "#/components/schemas/foo",
-        },
-      };
-      expect(getObject(item)).toMatchInlineSnapshot(`
-                                        "{
-                                          [key: string]: Foo;
-                                        }"
-                              `);
-    });
-
-    it("should deal with true as additionalProperties", () => {
-      const item = {
-        type: "object",
-        additionalProperties: true,
-      };
-      expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  [key: string]: any;
-                                                }"
-                                    `);
+                                                        "{
+                                                          [key: string]: string;
+                                                        }"
+                                          `);
     });
 
     it("should deal with ref additionalProperties", () => {
@@ -264,6 +238,32 @@ describe("scripts/import-open-api", () => {
                                     `);
     });
 
+    it("should deal with true as additionalProperties", () => {
+      const item = {
+        type: "object",
+        additionalProperties: true,
+      };
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                        "{
+                                                          [key: string]: any;
+                                                        }"
+                                          `);
+    });
+
+    it("should deal with ref additionalProperties", () => {
+      const item = {
+        type: "object",
+        additionalProperties: {
+          $ref: "#/components/schemas/foo",
+        },
+      };
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                        "{
+                                                          [key: string]: Foo;
+                                                        }"
+                                          `);
+    });
+
     it("should deal with oneOf additionalProperties", () => {
       const item = {
         type: "object",
@@ -272,10 +272,10 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  [key: string]: Foo | Bar;
-                                                }"
-                                    `);
+                                                        "{
+                                                          [key: string]: Foo | Bar;
+                                                        }"
+                                          `);
     });
 
     it("should deal with array as additionalProperties", () => {
@@ -290,10 +290,10 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  [key: string]: string[];
-                                                }"
-                                    `);
+                                                        "{
+                                                          [key: string]: string[];
+                                                        }"
+                                          `);
     });
 
     it("should deal with additionalProperties on top of define properties", () => {
@@ -308,11 +308,11 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "{
-                                                  name?: string;
-                                                  [key: string]: any;
-                                                }"
-                                    `);
+                                                        "{
+                                                          name?: string;
+                                                          [key: string]: any;
+                                                        }"
+                                          `);
     });
 
     it("should deal with allOf", () => {
@@ -330,10 +330,10 @@ describe("scripts/import-open-api", () => {
         ],
       };
       expect(getObject(item)).toMatchInlineSnapshot(`
-                                                "Foo & {
-                                                  name: string;
-                                                }"
-                                    `);
+                                                        "Foo & {
+                                                          name: string;
+                                                        }"
+                                          `);
     });
   });
 
@@ -446,12 +446,12 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
-        "export interface NewPet {
-          name: string;
-          tag?: string;
-        }
-        "
-      `);
+                "export interface NewPet {
+                  name: string;
+                  tag?: string;
+                }
+                "
+            `);
     });
 
     it("should declare an interface for simple object (nullable)", () => {
@@ -470,12 +470,12 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
-        "export type NewPet = {
-          name: string;
-          tag?: string;
-        } | null;
-        "
-      `);
+                "export type NewPet = {
+                  name: string;
+                  tag?: string;
+                } | null;
+                "
+            `);
     });
 
     it("should declare a type for union object", () => {
@@ -488,11 +488,11 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
-        "export type Pet = NewPet & {
-          id: number;
-        };
-        "
-      `);
+                "export type Pet = NewPet & {
+                  id: number;
+                };
+                "
+            `);
     });
 
     it("should declare a discriminate object", () => {
@@ -505,11 +505,11 @@ describe("scripts/import-open-api", () => {
         },
       };
       expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
-        "export type Pet = NewPet | {
-          id: number;
-        };
-        "
-      `);
+                "export type Pet = NewPet | {
+                  id: number;
+                };
+                "
+            `);
     });
 
     it("should declare a type for all others types", () => {
@@ -566,18 +566,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-                                                        "
-                                                        /**
-                                                         * Job is starting
-                                                         */
-                                                        export interface JobRunResponse {
-                                                          /**
-                                                           * ID of the job execution
-                                                           */
-                                                          executionID?: string;
-                                                        }
-                                                        "
-                                          `);
+                                                                "
+                                                                /**
+                                                                 * Job is starting
+                                                                 */
+                                                                export interface JobRunResponse {
+                                                                  /**
+                                                                   * ID of the job execution
+                                                                   */
+                                                                  executionID?: string;
+                                                                }
+                                                                "
+                                                `);
     });
 
     it("should give double quotes for special properties", () => {
@@ -601,18 +601,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-                                                        "
-                                                        /**
-                                                         * Job is starting
-                                                         */
-                                                        export interface JobRunResponse {
-                                                          /**
-                                                           * ID of the job execution
-                                                           */
-                                                          \\"execution-id\\"?: string;
-                                                        }
-                                                        "
-                                          `);
+                                                                "
+                                                                /**
+                                                                 * Job is starting
+                                                                 */
+                                                                export interface JobRunResponse {
+                                                                  /**
+                                                                   * ID of the job execution
+                                                                   */
+                                                                  \\"execution-id\\"?: string;
+                                                                }
+                                                                "
+                                                `);
     });
 
     it("should declare a a type for composed object", () => {
@@ -641,18 +641,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-                                                        "
-                                                        /**
-                                                         * Job is starting
-                                                         */
-                                                        export type JobRunResponse = {
-                                                          /**
-                                                           * ID of the job execution
-                                                           */
-                                                          executionID?: string;
-                                                        } & ExecutionID;
-                                                        "
-                                          `);
+                                                                "
+                                                                /**
+                                                                 * Job is starting
+                                                                 */
+                                                                export type JobRunResponse = {
+                                                                  /**
+                                                                   * ID of the job execution
+                                                                   */
+                                                                  executionID?: string;
+                                                                } & ExecutionID;
+                                                                "
+                                                `);
     });
 
     it("should declare a a type for union object", () => {
@@ -681,18 +681,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-                                                        "
-                                                        /**
-                                                         * Job is starting
-                                                         */
-                                                        export type JobRunResponse = {
-                                                          /**
-                                                           * ID of the job execution
-                                                           */
-                                                          executionID?: string;
-                                                        } | ExecutionID;
-                                                        "
-                                          `);
+                                                                "
+                                                                /**
+                                                                 * Job is starting
+                                                                 */
+                                                                export type JobRunResponse = {
+                                                                  /**
+                                                                   * ID of the job execution
+                                                                   */
+                                                                  executionID?: string;
+                                                                } | ExecutionID;
+                                                                "
+                                                `);
     });
   });
 
@@ -748,10 +748,10 @@ describe("scripts/import-open-api", () => {
       ];
 
       expect(getResReqTypes(responses)).toMatchInlineSnapshot(`
-                                        "FieldListResponse | {
-                                          id: string;
-                                        }"
-                              `);
+                                                "FieldListResponse | {
+                                                  id: string;
+                                                }"
+                                    `);
     });
 
     it("should not generate type duplication", () => {
@@ -800,26 +800,28 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, void>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should have a nice documentation with summary and description", () => {
@@ -837,28 +839,32 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                "
-                export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
 
-                /**
-                 * List all fields for the use case schema
-                 * 
-                 * This is a longer description to describe my endpoint
-                 */
-                export const ListFields = (props: ListFieldsProps) => (
-                  <Get<FieldListResponse, unknown, void>
-                    path={\`/fields\`}
-                    {...props}
-                  />
-                );
+        /**
+         * List all fields for the use case schema
+         * 
+         * This is a longer description to describe my endpoint
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, unknown, void>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                // List all fields for the use case schema
-                export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         * 
+         * This is a longer description to describe my endpoint
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
 
-                "
-            `);
+        "
+      `);
     });
 
     it("should add a fallback if the error is not defined", () => {
@@ -875,26 +881,28 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, unknown, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, unknown, void>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should remove duplicate types", () => {
@@ -924,26 +932,28 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, void>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should deal with parameters in query", () => {
@@ -988,28 +998,30 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
+        "
+        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
 
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
     it("should deal with parameters in query (root level)", () => {
       const operation: OperationObject = {
@@ -1060,28 +1072,30 @@ describe("scripts/import-open-api", () => {
           ],
         ),
       ).toMatchInlineSnapshot(`
-                        "
-                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
+        "
+        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
 
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should deal with parameters in path", () => {
@@ -1127,26 +1141,28 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields/{id}", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields/\${id}\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = ({id, ...props}: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, void>
+            path={\`/fields/\${id}\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
 
-                        // List all fields for the use case schema
-                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should deal with parameters in path (root level)", () => {
@@ -1199,26 +1215,28 @@ describe("scripts/import-open-api", () => {
           ],
         ),
       ).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields/\${id}\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = ({id, ...props}: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, void>
+            path={\`/fields/\${id}\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
 
-                        // List all fields for the use case schema
-                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should generate a Mutate type component", () => {
@@ -1264,27 +1282,29 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                        "
-                        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        "
+        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        /**
-                         * Update use case details
-                         */
-                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-                          <Mutate<UseCaseResponse, APIError, void, UseCaseInstance>
-                            verb=\\"PUT\\"
-                            path={\`/use-cases/\${useCaseId}\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * Update use case details
+         */
+        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+          <Mutate<UseCaseResponse, APIError, void, UseCaseInstance>
+            verb=\\"PUT\\"
+            path={\`/use-cases/\${useCaseId}\`}
+            {...props}
+          />
+        );
 
-                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        // Update use case details
-                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+        /**
+         * Update use case details
+         */
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
     it("should generate a proper ComponentResponse type if the type is custom", () => {
       const operation: OperationObject = {
@@ -1344,32 +1364,34 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                        "
-                        export interface UpdateUseCaseResponse {
-                          id: string;
-                          name?: string;
-                        }
+        "
+        export interface UpdateUseCaseResponse {
+          id: string;
+          name?: string;
+        }
 
-                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        /**
-                         * Update use case details
-                         */
-                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
-                            verb=\\"PUT\\"
-                            path={\`/use-cases/\${useCaseId}\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * Update use case details
+         */
+        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
+            verb=\\"PUT\\"
+            path={\`/use-cases/\${useCaseId}\`}
+            {...props}
+          />
+        );
 
-                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        // Update use case details
-                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+        /**
+         * Update use case details
+         */
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should ignore 3xx responses", () => {
@@ -1433,32 +1455,34 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                        "
-                        export interface UpdateUseCaseResponse {
-                          id: string;
-                          name?: string;
-                        }
+        "
+        export interface UpdateUseCaseResponse {
+          id: string;
+          name?: string;
+        }
 
-                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        /**
-                         * Update use case details
-                         */
-                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
-                            verb=\\"PUT\\"
-                            path={\`/use-cases/\${useCaseId}\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * Update use case details
+         */
+        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
+            verb=\\"PUT\\"
+            path={\`/use-cases/\${useCaseId}\`}
+            {...props}
+          />
+        );
 
-                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        // Update use case details
-                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+        /**
+         * Update use case details
+         */
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should ignore the last param of a delete call (the id is give after)", () => {
@@ -1499,27 +1523,29 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                        "
-                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\">;
+        "
+        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\">;
 
-                        /**
-                         * Delete use case
-                         */
-                        export const DeleteUseCase = (props: DeleteUseCaseProps) => (
-                          <Mutate<void, APIError, void, string>
-                            verb=\\"DELETE\\"
-                            path={\`/use-cases\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * Delete use case
+         */
+        export const DeleteUseCase = (props: DeleteUseCaseProps) => (
+          <Mutate<void, APIError, void, string>
+            verb=\\"DELETE\\"
+            path={\`/use-cases\`}
+            {...props}
+          />
+        );
 
-                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
+        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
 
-                        // Delete use case
-                        export const useDeleteUseCase = (props: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases\`, props);
+        /**
+         * Delete use case
+         */
+        export const useDeleteUseCase = (props: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
     it("should only remove the last params in delete operation", () => {
       const operation: OperationObject = {
@@ -1559,27 +1585,29 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}/secret", [])).toMatchInlineSnapshot(`
-                        "
-                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        "
+        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        /**
-                         * Delete use case
-                         */
-                        export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
-                          <Mutate<void, APIError, void, void>
-                            verb=\\"DELETE\\"
-                            path={\`/use-cases/\${useCaseId}/secret\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * Delete use case
+         */
+        export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
+          <Mutate<void, APIError, void, void>
+            verb=\\"DELETE\\"
+            path={\`/use-cases/\${useCaseId}/secret\`}
+            {...props}
+          />
+        );
 
-                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                        // Delete use case
-                        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
+        /**
+         * Delete use case
+         */
+        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
 
-                        "
-                  `);
+        "
+      `);
     });
 
     it("should generate a Poll compoment if the `prefer` token is present", () => {
@@ -1614,36 +1642,38 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+        "
+        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        /**
-                         * List all fields for the use case schema
-                         */
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        /**
+         * List all fields for the use case schema
+         */
+        export const ListFields = (props: ListFieldsProps) => (
+          <Get<FieldListResponse, APIError, void>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+        /**
+         * List all fields for the use case schema
+         */
+        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                        export type PollListFieldsProps = Omit<PollProps<FieldListResponse, APIError, void>, \\"path\\">;
+        export type PollListFieldsProps = Omit<PollProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        // List all fields for the use case schema (long polling)
-                        export const PollListFields = (props: PollListFieldsProps) => (
-                          <Poll<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+        // List all fields for the use case schema (long polling)
+        export const PollListFields = (props: PollListFieldsProps) => (
+          <Poll<FieldListResponse, APIError, void>
+            path={\`/fields\`}
+            {...props}
+          />
+        );
 
-                        "
-                  `);
+        "
+      `);
     });
   });
   it("should deal with no 2xx response case", () => {
@@ -1667,26 +1697,28 @@ describe("scripts/import-open-api", () => {
     };
 
     expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                  "
-                  export type ListFieldsProps = Omit<GetProps<void, APIError, void>, \\"path\\">;
+      "
+      export type ListFieldsProps = Omit<GetProps<void, APIError, void>, \\"path\\">;
 
-                  /**
-                   * List all fields for the use case schema
-                   */
-                  export const ListFields = (props: ListFieldsProps) => (
-                    <Get<void, APIError, void>
-                      path={\`/fields\`}
-                      {...props}
-                    />
-                  );
+      /**
+       * List all fields for the use case schema
+       */
+      export const ListFields = (props: ListFieldsProps) => (
+        <Get<void, APIError, void>
+          path={\`/fields\`}
+          {...props}
+        />
+      );
 
-                  export type UseListFieldsProps = Omit<UseGetProps<void, void>, \\"path\\">;
+      export type UseListFieldsProps = Omit<UseGetProps<void, void>, \\"path\\">;
 
-                  // List all fields for the use case schema
-                  export const useListFields = (props: UseListFieldsProps) => useGet<void, APIError, void>(\`/fields\`, props);
+      /**
+       * List all fields for the use case schema
+       */
+      export const useListFields = (props: UseListFieldsProps) => useGet<void, APIError, void>(\`/fields\`, props);
 
-                  "
-            `);
+      "
+    `);
   });
 
   describe("reactPropsValueToObjectValue", () => {

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -59,7 +59,7 @@ describe("scripts/import-open-api", () => {
       { item: { type: "array", items: { type: "string" } }, expected: "string[]" },
       { item: { type: "array", items: { type: "integer" } }, expected: "number[]" },
       { item: { type: "array", items: { type: "customType" } }, expected: "any[]" },
-      { item: { type: "object", properties: { value: { type: "integer" } } }, expected: "{value?: number}" },
+      { item: { type: "object", properties: { value: { type: "integer" } } }, expected: "{\n  value?: number;\n}" },
       { item: { type: "object" }, expected: "{[key: string]: any}" },
       { item: { type: "object", $ref: "#/components/schemas/Foo" }, expected: "Foo" },
       { item: { type: "string" }, expected: "string" },
@@ -181,7 +181,12 @@ describe("scripts/import-open-api", () => {
           },
         },
       };
-      expect(getObject(item)).toEqual(`{name: string; age: number}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  name: string;
+                                                  age: number;
+                                                }"
+                                    `);
     });
 
     it("should return the type of an object with optional values", () => {
@@ -197,7 +202,12 @@ describe("scripts/import-open-api", () => {
           },
         },
       };
-      expect(getObject(item)).toEqual(`{name: string; age?: number}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  name: string;
+                                                  age?: number;
+                                                }"
+                                    `);
     });
 
     it("should deal with additionalProperties", () => {
@@ -207,7 +217,11 @@ describe("scripts/import-open-api", () => {
           type: "string",
         },
       };
-      expect(getObject(item)).toEqual(`{[key: string]: string}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  [key: string]: string;
+                                                }"
+                                    `);
     });
 
     it("should deal with ref additionalProperties", () => {
@@ -217,7 +231,11 @@ describe("scripts/import-open-api", () => {
           $ref: "#/components/schemas/foo",
         },
       };
-      expect(getObject(item)).toEqual(`{[key: string]: Foo}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                        "{
+                                          [key: string]: Foo;
+                                        }"
+                              `);
     });
 
     it("should deal with true as additionalProperties", () => {
@@ -225,7 +243,11 @@ describe("scripts/import-open-api", () => {
         type: "object",
         additionalProperties: true,
       };
-      expect(getObject(item)).toEqual(`{[key: string]: any}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  [key: string]: any;
+                                                }"
+                                    `);
     });
 
     it("should deal with ref additionalProperties", () => {
@@ -235,7 +257,11 @@ describe("scripts/import-open-api", () => {
           $ref: "#/components/schemas/foo",
         },
       };
-      expect(getObject(item)).toEqual(`{[key: string]: Foo}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  [key: string]: Foo;
+                                                }"
+                                    `);
     });
 
     it("should deal with oneOf additionalProperties", () => {
@@ -245,7 +271,11 @@ describe("scripts/import-open-api", () => {
           oneOf: [{ $ref: "#/components/schemas/foo" }, { $ref: "#/components/schemas/bar" }],
         },
       };
-      expect(getObject(item)).toEqual(`{[key: string]: Foo | Bar}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  [key: string]: Foo | Bar;
+                                                }"
+                                    `);
     });
 
     it("should deal with array as additionalProperties", () => {
@@ -259,7 +289,11 @@ describe("scripts/import-open-api", () => {
         },
       };
 
-      expect(getObject(item)).toEqual(`{[key: string]: string[]}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  [key: string]: string[];
+                                                }"
+                                    `);
     });
 
     it("should deal with additionalProperties on top of define properties", () => {
@@ -273,7 +307,12 @@ describe("scripts/import-open-api", () => {
         additionalProperties: true,
       };
 
-      expect(getObject(item)).toEqual(`{name?: string; [key: string]: any}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "{
+                                                  name?: string;
+                                                  [key: string]: any;
+                                                }"
+                                    `);
     });
 
     it("should deal with allOf", () => {
@@ -290,7 +329,11 @@ describe("scripts/import-open-api", () => {
           },
         ],
       };
-      expect(getObject(item)).toEqual(`Foo & {name: string}`);
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                "Foo & {
+                                                  name: string;
+                                                }"
+                                    `);
     });
   });
 
@@ -402,7 +445,13 @@ describe("scripts/import-open-api", () => {
           },
         },
       };
-      expect(generateSchemasDefinition(schema)).toContain(`export interface NewPet {name: string; tag?: string}`);
+      expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
+        "export interface NewPet {
+          name: string;
+          tag?: string;
+        }
+        "
+      `);
     });
 
     it("should declare an interface for simple object (nullable)", () => {
@@ -420,7 +469,13 @@ describe("scripts/import-open-api", () => {
           },
         },
       };
-      expect(generateSchemasDefinition(schema)).toContain(`export type NewPet = {name: string; tag?: string} | null`);
+      expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
+        "export type NewPet = {
+          name: string;
+          tag?: string;
+        } | null;
+        "
+      `);
     });
 
     it("should declare a type for union object", () => {
@@ -432,7 +487,12 @@ describe("scripts/import-open-api", () => {
           ],
         },
       };
-      expect(generateSchemasDefinition(schema)).toContain(`export type Pet = NewPet & {id: number};`);
+      expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
+        "export type Pet = NewPet & {
+          id: number;
+        };
+        "
+      `);
     });
 
     it("should declare a discriminate object", () => {
@@ -444,7 +504,12 @@ describe("scripts/import-open-api", () => {
           ],
         },
       };
-      expect(generateSchemasDefinition(schema)).toContain(`export type Pet = NewPet | {id: number};`);
+      expect(generateSchemasDefinition(schema)).toMatchInlineSnapshot(`
+        "export type Pet = NewPet | {
+          id: number;
+        };
+        "
+      `);
     });
 
     it("should declare a type for all others types", () => {
@@ -501,13 +566,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-                "
-                /**
-                 * Job is starting
-                 */
-                export interface JobRunResponse {executionID?: string}
-                "
-            `);
+                                                        "
+                                                        /**
+                                                         * Job is starting
+                                                         */
+                                                        export interface JobRunResponse {
+                                                          /**
+                                                           * ID of the job execution
+                                                           */
+                                                          executionID?: string;
+                                                        }
+                                                        "
+                                          `);
     });
 
     it("should give double quotes for special properties", () => {
@@ -531,13 +601,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-                "
-                /**
-                 * Job is starting
-                 */
-                export interface JobRunResponse {\\"execution-id\\"?: string}
-                "
-            `);
+                                                        "
+                                                        /**
+                                                         * Job is starting
+                                                         */
+                                                        export interface JobRunResponse {
+                                                          /**
+                                                           * ID of the job execution
+                                                           */
+                                                          \\"execution-id\\"?: string;
+                                                        }
+                                                        "
+                                          `);
     });
 
     it("should declare a a type for composed object", () => {
@@ -566,13 +641,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-        "
-        /**
-         * Job is starting
-         */
-        export type JobRunResponse = {executionID?: string} & ExecutionID;
-        "
-      `);
+                                                        "
+                                                        /**
+                                                         * Job is starting
+                                                         */
+                                                        export type JobRunResponse = {
+                                                          /**
+                                                           * ID of the job execution
+                                                           */
+                                                          executionID?: string;
+                                                        } & ExecutionID;
+                                                        "
+                                          `);
     });
 
     it("should declare a a type for union object", () => {
@@ -601,13 +681,18 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
-        "
-        /**
-         * Job is starting
-         */
-        export type JobRunResponse = {executionID?: string} | ExecutionID;
-        "
-      `);
+                                                        "
+                                                        /**
+                                                         * Job is starting
+                                                         */
+                                                        export type JobRunResponse = {
+                                                          /**
+                                                           * ID of the job execution
+                                                           */
+                                                          executionID?: string;
+                                                        } | ExecutionID;
+                                                        "
+                                          `);
     });
   });
 
@@ -662,7 +747,11 @@ describe("scripts/import-open-api", () => {
         ],
       ];
 
-      expect(getResReqTypes(responses)).toEqual("FieldListResponse | {id: string}");
+      expect(getResReqTypes(responses)).toMatchInlineSnapshot(`
+                                        "FieldListResponse | {
+                                          id: string;
+                                        }"
+                              `);
     });
 
     it("should not generate type duplication", () => {
@@ -711,24 +800,65 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                                                        "
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+                        "
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = (props: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, void>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = (props: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, void>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
+    });
+
+    it("should have a nice documentation with summary and description", () => {
+      const operation: OperationObject = {
+        summary: "List all fields for the use case schema",
+        description: "This is a longer description to describe my endpoint",
+        operationId: "listFields",
+        tags: ["schema"],
+        responses: {
+          "200": {
+            description: "An array of schema fields",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/FieldListResponse" } } },
+          },
+        },
+      };
+
+      expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
+                "
+                export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
+
+                /**
+                 * List all fields for the use case schema
+                 * 
+                 * This is a longer description to describe my endpoint
+                 */
+                export const ListFields = (props: ListFieldsProps) => (
+                  <Get<FieldListResponse, unknown, void>
+                    path={\`/fields\`}
+                    {...props}
+                  />
+                );
+
+                export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+
+                // List all fields for the use case schema
+                export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
+
+                "
+            `);
     });
 
     it("should add a fallback if the error is not defined", () => {
@@ -745,24 +875,26 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                                                        "
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
+                        "
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = (props: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, unknown, void>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = (props: ListFieldsProps) => (
+                          <Get<FieldListResponse, unknown, void>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
 
     it("should remove duplicate types", () => {
@@ -792,24 +924,26 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                                                        "
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+                        "
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = (props: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, void>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = (props: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, void>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
 
     it("should deal with parameters in query", () => {
@@ -854,26 +988,28 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                                                        "
-                                                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
+                        "
+                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
 
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = (props: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = (props: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
     it("should deal with parameters in query (root level)", () => {
       const operation: OperationObject = {
@@ -924,26 +1060,28 @@ describe("scripts/import-open-api", () => {
           ],
         ),
       ).toMatchInlineSnapshot(`
-                                                        "
-                                                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
+                        "
+                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
 
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = (props: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = (props: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
 
     it("should deal with parameters in path", () => {
@@ -989,24 +1127,26 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields/{id}", [])).toMatchInlineSnapshot(`
-                                                        "
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
+                        "
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, void>
-                                                            path={\`/fields/\${id}\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, void>
+                            path={\`/fields/\${id}\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
 
     it("should deal with parameters in path (root level)", () => {
@@ -1059,24 +1199,26 @@ describe("scripts/import-open-api", () => {
           ],
         ),
       ).toMatchInlineSnapshot(`
-                                                        "
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
+                        "
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, void>
-                                                            path={\`/fields/\${id}\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, void>
+                            path={\`/fields/\${id}\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
 
     it("should generate a Mutate type component", () => {
@@ -1122,25 +1264,27 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                                        "
-                                        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        "
+                        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Update use case details
-                                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-                                          <Mutate<UseCaseResponse, APIError, void, UseCaseInstance>
-                                            verb=\\"PUT\\"
-                                            path={\`/use-cases/\${useCaseId}\`}
-                                            {...props}
-                                          />
-                                        );
+                        /**
+                         * Update use case details
+                         */
+                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+                          <Mutate<UseCaseResponse, APIError, void, UseCaseInstance>
+                            verb=\\"PUT\\"
+                            path={\`/use-cases/\${useCaseId}\`}
+                            {...props}
+                          />
+                        );
 
-                                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Update use case details
-                                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+                        // Update use case details
+                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-                                        "
-                              `);
+                        "
+                  `);
     });
     it("should generate a proper ComponentResponse type if the type is custom", () => {
       const operation: OperationObject = {
@@ -1200,27 +1344,32 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                                        "
-                                        export interface UpdateUseCaseResponse {id: string; name?: string}
+                        "
+                        export interface UpdateUseCaseResponse {
+                          id: string;
+                          name?: string;
+                        }
 
-                                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Update use case details
-                                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-                                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
-                                            verb=\\"PUT\\"
-                                            path={\`/use-cases/\${useCaseId}\`}
-                                            {...props}
-                                          />
-                                        );
+                        /**
+                         * Update use case details
+                         */
+                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
+                            verb=\\"PUT\\"
+                            path={\`/use-cases/\${useCaseId}\`}
+                            {...props}
+                          />
+                        );
 
-                                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Update use case details
-                                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+                        // Update use case details
+                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-                                        "
-                              `);
+                        "
+                  `);
     });
 
     it("should ignore 3xx responses", () => {
@@ -1284,27 +1433,32 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                                        "
-                                        export interface UpdateUseCaseResponse {id: string; name?: string}
+                        "
+                        export interface UpdateUseCaseResponse {
+                          id: string;
+                          name?: string;
+                        }
 
-                                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Update use case details
-                                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-                                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
-                                            verb=\\"PUT\\"
-                                            path={\`/use-cases/\${useCaseId}\`}
-                                            {...props}
-                                          />
-                                        );
+                        /**
+                         * Update use case details
+                         */
+                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
+                            verb=\\"PUT\\"
+                            path={\`/use-cases/\${useCaseId}\`}
+                            {...props}
+                          />
+                        );
 
-                                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Update use case details
-                                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+                        // Update use case details
+                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-                                        "
-                              `);
+                        "
+                  `);
     });
 
     it("should ignore the last param of a delete call (the id is give after)", () => {
@@ -1345,25 +1499,27 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-                                        "
-                                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\">;
+                        "
+                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\">;
 
-                                        // Delete use case
-                                        export const DeleteUseCase = (props: DeleteUseCaseProps) => (
-                                          <Mutate<void, APIError, void, string>
-                                            verb=\\"DELETE\\"
-                                            path={\`/use-cases\`}
-                                            {...props}
-                                          />
-                                        );
+                        /**
+                         * Delete use case
+                         */
+                        export const DeleteUseCase = (props: DeleteUseCaseProps) => (
+                          <Mutate<void, APIError, void, string>
+                            verb=\\"DELETE\\"
+                            path={\`/use-cases\`}
+                            {...props}
+                          />
+                        );
 
-                                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
+                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
 
-                                        // Delete use case
-                                        export const useDeleteUseCase = (props: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases\`, props);
+                        // Delete use case
+                        export const useDeleteUseCase = (props: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases\`, props);
 
-                                        "
-                              `);
+                        "
+                  `);
     });
     it("should only remove the last params in delete operation", () => {
       const operation: OperationObject = {
@@ -1403,25 +1559,27 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}/secret", [])).toMatchInlineSnapshot(`
-                                        "
-                                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        "
+                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Delete use case
-                                        export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
-                                          <Mutate<void, APIError, void, void>
-                                            verb=\\"DELETE\\"
-                                            path={\`/use-cases/\${useCaseId}/secret\`}
-                                            {...props}
-                                          />
-                                        );
+                        /**
+                         * Delete use case
+                         */
+                        export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
+                          <Mutate<void, APIError, void, void>
+                            verb=\\"DELETE\\"
+                            path={\`/use-cases/\${useCaseId}/secret\`}
+                            {...props}
+                          />
+                        );
 
-                                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-                                        // Delete use case
-                                        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
+                        // Delete use case
+                        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
 
-                                        "
-                              `);
+                        "
+                  `);
     });
 
     it("should generate a Poll compoment if the `prefer` token is present", () => {
@@ -1456,34 +1614,36 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                                                        "
-                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+                        "
+                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const ListFields = (props: ListFieldsProps) => (
-                                                          <Get<FieldListResponse, APIError, void>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        /**
+                         * List all fields for the use case schema
+                         */
+                        export const ListFields = (props: ListFieldsProps) => (
+                          <Get<FieldListResponse, APIError, void>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema
-                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+                        // List all fields for the use case schema
+                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                                                        export type PollListFieldsProps = Omit<PollProps<FieldListResponse, APIError, void>, \\"path\\">;
+                        export type PollListFieldsProps = Omit<PollProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                                                        // List all fields for the use case schema (long polling)
-                                                        export const PollListFields = (props: PollListFieldsProps) => (
-                                                          <Poll<FieldListResponse, APIError, void>
-                                                            path={\`/fields\`}
-                                                            {...props}
-                                                          />
-                                                        );
+                        // List all fields for the use case schema (long polling)
+                        export const PollListFields = (props: PollListFieldsProps) => (
+                          <Poll<FieldListResponse, APIError, void>
+                            path={\`/fields\`}
+                            {...props}
+                          />
+                        );
 
-                                                        "
-                                          `);
+                        "
+                  `);
     });
   });
   it("should deal with no 2xx response case", () => {
@@ -1507,24 +1667,26 @@ describe("scripts/import-open-api", () => {
     };
 
     expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                                          "
-                                          export type ListFieldsProps = Omit<GetProps<void, APIError, void>, \\"path\\">;
+                  "
+                  export type ListFieldsProps = Omit<GetProps<void, APIError, void>, \\"path\\">;
 
-                                          // List all fields for the use case schema
-                                          export const ListFields = (props: ListFieldsProps) => (
-                                            <Get<void, APIError, void>
-                                              path={\`/fields\`}
-                                              {...props}
-                                            />
-                                          );
+                  /**
+                   * List all fields for the use case schema
+                   */
+                  export const ListFields = (props: ListFieldsProps) => (
+                    <Get<void, APIError, void>
+                      path={\`/fields\`}
+                      {...props}
+                    />
+                  );
 
-                                          export type UseListFieldsProps = Omit<UseGetProps<void, void>, \\"path\\">;
+                  export type UseListFieldsProps = Omit<UseGetProps<void, void>, \\"path\\">;
 
-                                          // List all fields for the use case schema
-                                          export const useListFields = (props: UseListFieldsProps) => useGet<void, APIError, void>(\`/fields\`, props);
+                  // List all fields for the use case schema
+                  export const useListFields = (props: UseListFieldsProps) => useGet<void, APIError, void>(\`/fields\`, props);
 
-                                          "
-                            `);
+                  "
+            `);
   });
 
   describe("reactPropsValueToObjectValue", () => {

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -500,9 +500,14 @@ describe("scripts/import-open-api", () => {
         },
       };
 
-      expect(generateResponsesDefinition(responses)).toContain(
-        "export interface JobRunResponse {executionID?: string}",
-      );
+      expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
+                "
+                /**
+                 * Job is starting
+                 */
+                export interface JobRunResponse {executionID?: string}
+                "
+            `);
     });
 
     it("should give double quotes for special properties", () => {
@@ -525,9 +530,14 @@ describe("scripts/import-open-api", () => {
         },
       };
 
-      expect(generateResponsesDefinition(responses)).toContain(
-        `export interface JobRunResponse {"execution-id"?: string}`,
-      );
+      expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
+                "
+                /**
+                 * Job is starting
+                 */
+                export interface JobRunResponse {\\"execution-id\\"?: string}
+                "
+            `);
     });
 
     it("should declare a a type for composed object", () => {
@@ -555,9 +565,14 @@ describe("scripts/import-open-api", () => {
         },
       };
 
-      expect(generateResponsesDefinition(responses)).toContain(
-        "export type JobRunResponse = {executionID?: string} & ExecutionID",
-      );
+      expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
+        "
+        /**
+         * Job is starting
+         */
+        export type JobRunResponse = {executionID?: string} & ExecutionID;
+        "
+      `);
     });
 
     it("should declare a a type for union object", () => {
@@ -585,9 +600,14 @@ describe("scripts/import-open-api", () => {
         },
       };
 
-      expect(generateResponsesDefinition(responses)).toContain(
-        "export type JobRunResponse = {executionID?: string} | ExecutionID",
-      );
+      expect(generateResponsesDefinition(responses)).toMatchInlineSnapshot(`
+        "
+        /**
+         * Job is starting
+         */
+        export type JobRunResponse = {executionID?: string} | ExecutionID;
+        "
+      `);
     });
   });
 
@@ -691,24 +711,24 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+                                                        "
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = (props: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, void>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
 
     it("should add a fallback if the error is not defined", () => {
@@ -725,24 +745,24 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
+                                                        "
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, unknown, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, unknown, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = (props: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, unknown, void>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, unknown, void>(\`/fields\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
 
     it("should remove duplicate types", () => {
@@ -772,24 +792,24 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+                                                        "
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = (props: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, void>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
 
     it("should deal with parameters in query", () => {
@@ -834,26 +854,26 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
+                                                        "
+                                                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
 
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = (props: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
     it("should deal with parameters in query (root level)", () => {
       const operation: OperationObject = {
@@ -904,26 +924,26 @@ describe("scripts/import-open-api", () => {
           ],
         ),
       ).toMatchInlineSnapshot(`
-                        "
-                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
+                                                        "
+                                                        export interface ListFieldsQueryParams {tenantId: string; projectId?: string}
 
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, ListFieldsQueryParams>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = (props: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, ListFieldsQueryParams>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, ListFieldsQueryParams>(\`/fields\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
 
     it("should deal with parameters in path", () => {
@@ -969,24 +989,24 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields/{id}", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
+                                                        "
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
 
-                        // List all fields for the use case schema
-                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields/\${id}\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, void>
+                                                            path={\`/fields/\${id}\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
 
-                        // List all fields for the use case schema
-                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
 
     it("should deal with parameters in path (root level)", () => {
@@ -1039,24 +1059,24 @@ describe("scripts/import-open-api", () => {
           ],
         ),
       ).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
+                                                        "
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\"> & {id: string};
 
-                        // List all fields for the use case schema
-                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields/\${id}\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = ({id, ...props}: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, void>
+                                                            path={\`/fields/\${id}\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\"> & {id: string};
 
-                        // List all fields for the use case schema
-                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields/\${id}\`, props);
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
 
     it("should generate a Mutate type component", () => {
@@ -1102,25 +1122,25 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-        "
-        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        "
+                                        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Update use case details
-        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-          <Mutate<UseCaseResponse, APIError, void, UseCaseInstance>
-            verb=\\"PUT\\"
-            path={\`/use-cases/\${useCaseId}\`}
-            {...props}
-          />
-        );
+                                        // Update use case details
+                                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+                                          <Mutate<UseCaseResponse, APIError, void, UseCaseInstance>
+                                            verb=\\"PUT\\"
+                                            path={\`/use-cases/\${useCaseId}\`}
+                                            {...props}
+                                          />
+                                        );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Update use case details
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+                                        // Update use case details
+                                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-        "
-      `);
+                                        "
+                              `);
     });
     it("should generate a proper ComponentResponse type if the type is custom", () => {
       const operation: OperationObject = {
@@ -1180,27 +1200,27 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-        "
-        export interface UpdateUseCaseResponse {id: string; name?: string}
+                                        "
+                                        export interface UpdateUseCaseResponse {id: string; name?: string}
 
-        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Update use case details
-        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
-            verb=\\"PUT\\"
-            path={\`/use-cases/\${useCaseId}\`}
-            {...props}
-          />
-        );
+                                        // Update use case details
+                                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+                                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
+                                            verb=\\"PUT\\"
+                                            path={\`/use-cases/\${useCaseId}\`}
+                                            {...props}
+                                          />
+                                        );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Update use case details
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+                                        // Update use case details
+                                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-        "
-      `);
+                                        "
+                              `);
     });
 
     it("should ignore 3xx responses", () => {
@@ -1264,27 +1284,27 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-        "
-        export interface UpdateUseCaseResponse {id: string; name?: string}
+                                        "
+                                        export interface UpdateUseCaseResponse {id: string; name?: string}
 
-        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        export type UpdateUseCaseProps = Omit<MutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Update use case details
-        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
-          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
-            verb=\\"PUT\\"
-            path={\`/use-cases/\${useCaseId}\`}
-            {...props}
-          />
-        );
+                                        // Update use case details
+                                        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+                                          <Mutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>
+                                            verb=\\"PUT\\"
+                                            path={\`/use-cases/\${useCaseId}\`}
+                                            {...props}
+                                          />
+                                        );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Update use case details
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+                                        // Update use case details
+                                        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
 
-        "
-      `);
+                                        "
+                              `);
     });
 
     it("should ignore the last param of a delete call (the id is give after)", () => {
@@ -1325,25 +1345,25 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
-        "
-        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\">;
+                                        "
+                                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, string>, \\"path\\" | \\"verb\\">;
 
-        // Delete use case
-        export const DeleteUseCase = (props: DeleteUseCaseProps) => (
-          <Mutate<void, APIError, void, string>
-            verb=\\"DELETE\\"
-            path={\`/use-cases\`}
-            {...props}
-          />
-        );
+                                        // Delete use case
+                                        export const DeleteUseCase = (props: DeleteUseCaseProps) => (
+                                          <Mutate<void, APIError, void, string>
+                                            verb=\\"DELETE\\"
+                                            path={\`/use-cases\`}
+                                            {...props}
+                                          />
+                                        );
 
-        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
+                                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string>, \\"path\\" | \\"verb\\">;
 
-        // Delete use case
-        export const useDeleteUseCase = (props: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases\`, props);
+                                        // Delete use case
+                                        export const useDeleteUseCase = (props: UseDeleteUseCaseProps) => useMutate<void, APIError, void, string>(\\"DELETE\\", \`/use-cases\`, props);
 
-        "
-      `);
+                                        "
+                              `);
     });
     it("should only remove the last params in delete operation", () => {
       const operation: OperationObject = {
@@ -1383,25 +1403,25 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "delete", "/use-cases/{useCaseId}/secret", [])).toMatchInlineSnapshot(`
-        "
-        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        "
+                                        export type DeleteUseCaseProps = Omit<MutateProps<void, APIError, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Delete use case
-        export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
-          <Mutate<void, APIError, void, void>
-            verb=\\"DELETE\\"
-            path={\`/use-cases/\${useCaseId}/secret\`}
-            {...props}
-          />
-        );
+                                        // Delete use case
+                                        export const DeleteUseCase = ({useCaseId, ...props}: DeleteUseCaseProps) => (
+                                          <Mutate<void, APIError, void, void>
+                                            verb=\\"DELETE\\"
+                                            path={\`/use-cases/\${useCaseId}/secret\`}
+                                            {...props}
+                                          />
+                                        );
 
-        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+                                        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
 
-        // Delete use case
-        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
+                                        // Delete use case
+                                        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void>(\\"DELETE\\", \`/use-cases/\${useCaseId}/secret\`, props);
 
-        "
-      `);
+                                        "
+                              `);
     });
 
     it("should generate a Poll compoment if the `prefer` token is present", () => {
@@ -1436,34 +1456,34 @@ describe("scripts/import-open-api", () => {
       };
 
       expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                        "
-                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
+                                                        "
+                                                        export type ListFieldsProps = Omit<GetProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const ListFields = (props: ListFieldsProps) => (
-                          <Get<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema
+                                                        export const ListFields = (props: ListFieldsProps) => (
+                                                          <Get<FieldListResponse, APIError, void>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
+                                                        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void>, \\"path\\">;
 
-                        // List all fields for the use case schema
-                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
+                                                        // List all fields for the use case schema
+                                                        export const useListFields = (props: UseListFieldsProps) => useGet<FieldListResponse, APIError, void>(\`/fields\`, props);
 
-                        export type PollListFieldsProps = Omit<PollProps<FieldListResponse, APIError, void>, \\"path\\">;
+                                                        export type PollListFieldsProps = Omit<PollProps<FieldListResponse, APIError, void>, \\"path\\">;
 
-                        // List all fields for the use case schema (long polling)
-                        export const PollListFields = (props: PollListFieldsProps) => (
-                          <Poll<FieldListResponse, APIError, void>
-                            path={\`/fields\`}
-                            {...props}
-                          />
-                        );
+                                                        // List all fields for the use case schema (long polling)
+                                                        export const PollListFields = (props: PollListFieldsProps) => (
+                                                          <Poll<FieldListResponse, APIError, void>
+                                                            path={\`/fields\`}
+                                                            {...props}
+                                                          />
+                                                        );
 
-                        "
-                  `);
+                                                        "
+                                          `);
     });
   });
   it("should deal with no 2xx response case", () => {
@@ -1487,24 +1507,24 @@ describe("scripts/import-open-api", () => {
     };
 
     expect(generateRestfulComponent(operation, "get", "/fields", [])).toMatchInlineSnapshot(`
-                  "
-                  export type ListFieldsProps = Omit<GetProps<void, APIError, void>, \\"path\\">;
+                                          "
+                                          export type ListFieldsProps = Omit<GetProps<void, APIError, void>, \\"path\\">;
 
-                  // List all fields for the use case schema
-                  export const ListFields = (props: ListFieldsProps) => (
-                    <Get<void, APIError, void>
-                      path={\`/fields\`}
-                      {...props}
-                    />
-                  );
+                                          // List all fields for the use case schema
+                                          export const ListFields = (props: ListFieldsProps) => (
+                                            <Get<void, APIError, void>
+                                              path={\`/fields\`}
+                                              {...props}
+                                            />
+                                          );
 
-                  export type UseListFieldsProps = Omit<UseGetProps<void, void>, \\"path\\">;
+                                          export type UseListFieldsProps = Omit<UseGetProps<void, void>, \\"path\\">;
 
-                  // List all fields for the use case schema
-                  export const useListFields = (props: UseListFieldsProps) => useGet<void, APIError, void>(\`/fields\`, props);
+                                          // List all fields for the use case schema
+                                          export const useListFields = (props: UseListFieldsProps) => useGet<void, APIError, void>(\`/fields\`, props);
 
-                  "
-            `);
+                                          "
+                            `);
   });
 
   describe("reactPropsValueToObjectValue", () => {


### PR DESCRIPTION
# Why

Expose `summary` and `description` in the generated components/types from open-api specs

![image](https://user-images.githubusercontent.com/1761469/70861676-df64b880-1f31-11ea-9745-9748ce5d36fd.png)

Fix #184 
