### PR TITLE
Support requestBody fields that are reference objects

### DIFF
--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -52,6 +52,8 @@ export interface Error {
   message: string;
 }
 
+export type UpdatePetRequestRequestBody = NewPet;
+
 export interface FindPetsQueryParams {
   /**
    * tags to filter by
@@ -151,6 +153,27 @@ export type UseDeletePetProps = Omit<UseMutateProps<void, void, string>, \\"path
  * deletes a single pet based on the ID supplied
  */
 export const useDeletePet = (props: UseDeletePetProps) => useMutate<void, Error, void, string>(\\"DELETE\\", \`/pets\`, props);
+
+
+export type UpdatePetProps = Omit<MutateProps<Pet, Error, void, UpdatePetRequestRequestBody>, \\"path\\" | \\"verb\\"> & {id: number};
+
+/**
+ * Updates a pet in the store.
+ */
+export const UpdatePet = ({id, ...props}: UpdatePetProps) => (
+  <Mutate<Pet, Error, void, UpdatePetRequestRequestBody>
+    verb=\\"PATCH\\"
+    path={\`/pets/\${id}\`}
+    {...props}
+  />
+);
+
+export type UseUpdatePetProps = Omit<UseMutateProps<Pet, void, UpdatePetRequestRequestBody>, \\"path\\" | \\"verb\\"> & {id: number};
+
+/**
+ * Updates a pet in the store.
+ */
+export const useUpdatePet = ({id, ...props}: UseUpdatePetProps) => useMutate<Pet, Error, void, UpdatePetRequestRequestBody>(\\"PATCH\\", \`/pets/\${id}\`, props);
 
 "
 `;

--- a/src/scripts/tests/petstore-expanded.yaml
+++ b/src/scripts/tests/petstore-expanded.yaml
@@ -122,7 +122,40 @@ paths:
             application/json:
               schema:
                 $ref: "#/components/schemas/Error"
+    patch:
+      description: Updates a pet in the store.
+      operationId: updatePet
+      parameters:
+        - name: id
+          in: path
+          description: ID of pet to update
+          required: true
+          schema:
+            type: integer
+            format: int64
+      requestBody:
+        $ref: "#/components/requestBodies/updatePetRequest"
+      responses:
+        "200":
+          description: pet response
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Pet"
+        default:
+          description: unexpected error
+          content:
+            application/json:
+              schema:
+                $ref: "#/components/schemas/Error"
 components:
+  requestBodies:
+    updatePetRequest:
+      content:
+        application/json:
+          schema:
+            $ref: "#/components/schemas/NewPet"
+      required: true
   schemas:
     Pet:
       description: A pet.
@@ -153,8 +186,8 @@ components:
       discriminator:
         propertyName: type
         mapping:
-           cat: "#/components/schemas/Cat"
-           dog: "#/components/schemas/Dog"
+          cat: "#/components/schemas/Cat"
+          dog: "#/components/schemas/Dog"
 
     Cat:
       description: A cat, meow.
@@ -181,9 +214,9 @@ components:
         breed:
           type: string
           enum:
-           - saimois
-           - bengal
-           - british shorthair
+            - saimois
+            - bengal
+            - british shorthair
       required:
         - type
         - breed


### PR DESCRIPTION
Fixes #177 

As per the OpenApi spec, `requestBody` inside the `Operation` object may be a reference. Previously restful-react was not generating types for this case.

I added a new endpoint to the extended petstore yaml that exhibits this behavior for testing.