### PR TITLE
Route fix for generated 'delete' components from openapi

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -279,7 +279,7 @@ export const generateRestfulComponent = (
   // Remove the last param of the route if we are in the DELETE case
   let lastParamInTheRoute: string | null = null;
   if (verb === "delete") {
-    const lastParamInTheRouteRegExp = /\/\$\{(\w+)\}$/;
+    const lastParamInTheRouteRegExp = /\/\$\{(\w+)\}\/?$/;
     lastParamInTheRoute = (route.match(lastParamInTheRouteRegExp) || [])[1];
     route = route.replace(lastParamInTheRouteRegExp, ""); // `/pet/${id}` => `/pet`
   }


### PR DESCRIPTION
This fix allows us to use generated useDelete or delete react component even the route has a trailing slash (my_route/${id}/).

# Why

Generated route for using delete components works only when the route has no trailing slash (my_route/${id}).
