### PR TITLE
Generate a separate type for `RequestBody`

### DIFF
--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -40,7 +40,11 @@ program.option("--config [value]", "override flags by a config file");
 program.parse(process.argv);
 
 const createSuccessMessage = (backend?: string) =>
-  chalk.green(`${backend || ""}🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`);
+  chalk.green(
+    `${
+      backend ? `[${backend}] ` : ""
+    }🎉  Your OpenAPI spec has been converted into ready to use restful-react components!`,
+  );
 
 const successWithoutOutputMessage = chalk.yellow("Success! No output path specified; printed to standard output.");
 

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -293,6 +293,7 @@ export const generateRestfulComponent = (
   const responseTypes = getResReqTypes(Object.entries(operation.responses).filter(isOk)) || "void";
   const errorTypes = getResReqTypes(Object.entries(operation.responses).filter(isError)) || "unknown";
   const requestBodyTypes = getResReqTypes([["body", operation.requestBody!]]);
+  const needARequestBodyComponent = requestBodyTypes.includes("{");
   const needAResponseComponent = responseTypes.includes("{");
 
   /**
@@ -349,7 +350,13 @@ export const generateRestfulComponent = (
         }`
       : `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${errorTypes}, ${
           queryParamsType ? componentName + "QueryParams" : "void"
-        }, ${verb === "delete" && lastParamInTheRoute ? "string" : requestBodyTypes}`;
+        }, ${
+          verb === "delete" && lastParamInTheRoute
+            ? "string"
+            : needARequestBodyComponent
+            ? componentName + "RequestBody"
+            : requestBodyTypes
+        }`;
 
   const genericsTypesForHooksProps =
     verb === "get"
@@ -358,7 +365,13 @@ export const generateRestfulComponent = (
         }`
       : `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${
           queryParamsType ? componentName + "QueryParams" : "void"
-        }, ${verb === "delete" && lastParamInTheRoute ? "string" : requestBodyTypes}`;
+        }, ${
+          verb === "delete" && lastParamInTheRoute
+            ? "string"
+            : needARequestBodyComponent
+            ? componentName + "RequestBody"
+            : requestBodyTypes
+        }`;
 
   const customPropsEntries = Object.entries(customProps);
 
@@ -376,6 +389,12 @@ export ${
 export interface ${componentName}QueryParams {
   ${queryParamsType};
 }
+`
+      : ""
+  }${
+    needARequestBodyComponent
+      ? `
+export interface ${componentName}RequestBody ${requestBodyTypes}
 `
       : ""
   }

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -1330,6 +1330,92 @@ describe("scripts/import-open-api", () => {
                 "
             `);
     });
+
+    it("should generate a request body type if it's inline in the specs", () => {
+      const operation: OperationObject = {
+        summary: "Update use case details",
+        operationId: "updateUseCase",
+        tags: ["use-case"],
+        parameters: [
+          {
+            name: "useCaseId",
+            in: "path",
+            required: true,
+            description: "The id of the use case",
+            schema: { type: "string", format: "uuid" },
+          },
+        ],
+        requestBody: {
+          required: true,
+          content: {
+            "application/json": {
+              schema: {
+                type: "object",
+                required: ["name"],
+                properties: {
+                  name: {
+                    type: "string",
+                    description: "The use case name",
+                  },
+                  description: {
+                    type: "string",
+                  },
+                },
+              },
+            },
+          },
+        },
+        responses: {
+          "204": {
+            description: "Use case updated",
+            content: { "application/json": { schema: { $ref: "#/components/schemas/UseCaseResponse" } } },
+          },
+          default: {
+            description: "unexpected error",
+            content: {
+              "application/json": {
+                schema: { $ref: "#/components/schemas/APIError" },
+                example: { errors: ["msg1", "msg2"] },
+              },
+            },
+          },
+        },
+      };
+
+      expect(generateRestfulComponent(operation, "put", "/use-cases/{useCaseId}", [])).toMatchInlineSnapshot(`
+        "
+        export interface UpdateUseCaseRequestBody {
+          /**
+           * The use case name
+           */
+          name: string;
+          description?: string;
+        }
+
+        export type UpdateUseCaseProps = Omit<MutateProps<UseCaseResponse, APIError, void, UpdateUseCaseRequestBody>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+
+        /**
+         * Update use case details
+         */
+        export const UpdateUseCase = ({useCaseId, ...props}: UpdateUseCaseProps) => (
+          <Mutate<UseCaseResponse, APIError, void, UpdateUseCaseRequestBody>
+            verb=\\"PUT\\"
+            path={\`/use-cases/\${useCaseId}\`}
+            {...props}
+          />
+        );
+
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UpdateUseCaseRequestBody>, \\"path\\" | \\"verb\\"> & {useCaseId: string};
+
+        /**
+         * Update use case details
+         */
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UpdateUseCaseRequestBody>(\\"PUT\\", \`/use-cases/\${useCaseId}\`, props);
+
+        "
+      `);
+    });
+
     it("should generate a proper ComponentResponse type if the type is custom", () => {
       const operation: OperationObject = {
         summary: "Update use case details",


### PR DESCRIPTION
# Why

Inline types are hard to consume (and probably break with documentation ^^) so let's export them correctly for `RequestBody`

# Related issue
#225 
