### PR TITLE
Custom generator

### DIFF
--- a/README.md
+++ b/README.md
@@ -639,6 +639,16 @@ interface RestfulReactConfig {
     customProps?: {
       base?: string;
     };
+    customGenerator?: (data: {
+    componentName: string;
+    verb: string;
+    route: string;
+    description: string;
+    genericsTypes: string;
+    operation: OperationObject;
+    paramsInPath: string[];
+    paramsTypes: string;
+  }) => string;
   };
 }
 ```
@@ -675,6 +685,16 @@ module.exports = {
   }
 }
 ```
+
+##### Custom generator
+
+To support even more advanced usecases (like a promise base API, mock generator or anything else that can infer from your specs), you can define your own template in `customGenerator`. This function will be call for each route with some useful computed values (see the types above) and the resulted string will be added to the generated file.
+
+You can see a concrete usage inside the `examples` folder and try yourself in this repository with the following command:
+- `yarn build`
+- `yarn example:advanced petstore-custom-fetch`
+
+You can inspect the result inside `/examples/petstoreFromFileSpecWithCustomFetch.tsx`
 
 ## Contributing
 

--- a/examples/fetchers.ts
+++ b/examples/fetchers.ts
@@ -1,0 +1,76 @@
+import qs from "qs";
+
+export interface CustomGetProps<
+  _TData = any,
+  _TError = any,
+  TQueryParams = {
+    [key: string]: any;
+  }
+> {
+  queryParams?: TQueryParams;
+}
+
+export const customGet = <
+  TData = any,
+  TError = any,
+  TQueryParams = {
+    [key: string]: any;
+  }
+>(
+  path: string,
+  props: { queryParams?: TQueryParams },
+  signal?: RequestInit["signal"],
+): Promise<TData | TError> => {
+  let url = path;
+  if (props.queryParams && Object.keys(props.queryParams).length) {
+    url += `?${qs.stringify(props.queryParams)}`;
+  }
+  return fetch(url, {
+    headers: {
+      "content-type": "application/json",
+    },
+    signal,
+  }).then(res => res.json());
+};
+
+export interface CustomMutateProps<
+  _TData = any,
+  _TError = any,
+  TQueryParams = {
+    [key: string]: any;
+  },
+  TRequestBody = any
+> {
+  body: TRequestBody;
+  queryParams?: TQueryParams;
+}
+
+export const customMutate = <
+  TData = any,
+  TError = any,
+  TQueryParams = {
+    [key: string]: any;
+  },
+  TRequestBody = any
+>(
+  method: string,
+  path: string,
+  props: { body: TRequestBody; queryParams?: TQueryParams },
+  signal?: RequestInit["signal"],
+): Promise<TData | TError> => {
+  let url = path;
+  if (method === "DELETE" && typeof props.body === "string") {
+    url += `/${props.body}`;
+  }
+  if (props.queryParams && Object.keys(props.queryParams).length) {
+    url += `?${qs.stringify(props.queryParams)}`;
+  }
+  return fetch(url, {
+    method,
+    body: JSON.stringify(props.body),
+    headers: {
+      "content-type": "application/json",
+    },
+    signal,
+  }).then(res => res.json());
+};

--- a/examples/restful-react.config.js
+++ b/examples/restful-react.config.js
@@ -2,6 +2,8 @@
  * Example config for `yarn example:advanced`
  */
 
+const { camel } = require("case");
+
 module.exports = {
   "petstore-file": {
     file: "examples/petstore.yaml",
@@ -13,6 +15,27 @@ module.exports = {
     customImport: "/* a custom import */",
     customProps: {
       base: `"http://my-pet-store.com"`,
+    },
+  },
+  "petstore-custom-fetch": {
+    file: "examples/petstore.yaml",
+    output: "examples/petstoreFromFileSpecWithCustomFetch.tsx",
+    customImport: `import { customGet, customMutate, CustomGetProps, CustomMutateProps } from "./fetchers"`,
+    customGenerator: ({ componentName, verb, route, description, genericsTypes, paramsInPath, paramsTypes }) => {
+      const propsType = type =>
+        `Custom${type}Props<${genericsTypes}>${paramsInPath.length ? ` & {${paramsTypes}}` : ""}`;
+
+      return verb === "get"
+        ? `${description}export const ${camel(componentName)} = (${
+            paramsInPath.length ? `{${paramsInPath.join(", ")}, ...props}` : "props"
+          }: ${propsType(
+            "Get",
+          )}, signal?: RequestInit["signal"]) => customGet<${genericsTypes}>(\`http://petstore.swagger.io/v1${route}\`, props, signal);\n\n`
+        : `${description}export const ${camel(componentName)} = (${
+            paramsInPath.length ? `{${paramsInPath.join(", ")}, ...props}` : "props"
+          }: ${propsType(
+            "Mutate",
+          )}, signal?: RequestInit["signal"]) => customMutate<${genericsTypes}>("${verb.toUpperCase()}", \`http://petstore.swagger.io/v1${route}\`, props, signal);\n\n`;
     },
   },
 };

--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -32,6 +32,8 @@ export type AdvancedOptions = Options & {
     description: string;
     genericsTypes: string;
     operation: OperationObject;
+    paramsInPath: string[];
+    paramsTypes: string;
   }) => string;
 };
 

--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -7,6 +7,7 @@ import { join, parse } from "path";
 import request from "request";
 
 import importOpenApi from "../scripts/import-open-api";
+import { OperationObject } from "openapi3-ts";
 
 const log = console.log; // tslint:disable-line:no-console
 
@@ -24,6 +25,14 @@ export type AdvancedOptions = Options & {
   customProps?: {
     base?: string;
   };
+  customGenerator?: (data: {
+    componentName: string;
+    verb: string;
+    route: string;
+    description: string;
+    genericsTypes: string;
+    operation: OperationObject;
+  }) => string;
 };
 
 export interface ExternalConfigFile {
@@ -67,6 +76,7 @@ const importSpecs = async (options: AdvancedOptions) => {
       validation: options.validation,
       customImport: options.customImport,
       customProps: options.customProps,
+      customGenerator: options.customGenerator,
     });
   } else if (options.url) {
     const { url } = options;
@@ -101,6 +111,7 @@ const importSpecs = async (options: AdvancedOptions) => {
             validation: options.validation,
             customImport: options.customImport,
             customProps: options.customProps,
+            customGenerator: options.customGenerator,
           }),
         );
       });
@@ -187,6 +198,7 @@ const importSpecs = async (options: AdvancedOptions) => {
             validation: options.validation,
             customImport: options.customImport,
             customProps: options.customProps,
+            customGenerator: options.customGenerator,
           }),
         );
       });

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -470,6 +470,8 @@ ${description}export const use${componentName} = (${
       route,
       description,
       genericsTypes,
+      paramsInPath,
+      paramsTypes,
       operation,
     });
   }

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -129,6 +129,19 @@ export const getObject = (item: SchemaObject): string => {
     return item.oneOf.map(resolveValue).join(" | ");
   }
 
+  if (!item.type && !item.properties && !item.additionalProperties) {
+    return "{}";
+  }
+
+  // Free form object (https://swagger.io/docs/specification/data-models/data-types/#free-form)
+  if (
+    item.type === "object" &&
+    !item.properties &&
+    (!item.additionalProperties || item.additionalProperties === true || isEmpty(item.additionalProperties))
+  ) {
+    return "{[key: string]: any}";
+  }
+
   // Consolidation of item.properties & item.additionalProperties
   let output = "{\n";
   if (item.properties) {
@@ -151,7 +164,8 @@ export const getObject = (item: SchemaObject): string => {
     };`;
   }
 
-  if (output !== "{\n") {
+  if (item.properties || item.additionalProperties) {
+    if (output === "{\n") return "{}";
     return output + "\n}";
   }
 

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -243,11 +243,7 @@ describe("scripts/import-open-api", () => {
         type: "object",
         additionalProperties: true,
       };
-      expect(getObject(item)).toMatchInlineSnapshot(`
-                                                                "{
-                                                                  [key: string]: any;
-                                                                }"
-                                                `);
+      expect(getObject(item)).toMatchInlineSnapshot(`"{[key: string]: any}"`);
     });
 
     it("should deal with ref additionalProperties", () => {
@@ -335,11 +331,35 @@ describe("scripts/import-open-api", () => {
                                                                 }"
                                                 `);
     });
-    it("should handle empty properties", () => {
+    it("should handle empty properties (1)", () => {
       const item = {
         properties: {},
       };
-      expect(getObject(item)).toMatchInlineSnapshot(`"any"`);
+      expect(getObject(item)).toMatchInlineSnapshot(`"{}"`);
+    });
+    it("should handle empty properties (2)", () => {
+      const item = {};
+      expect(getObject(item)).toMatchInlineSnapshot(`"{}"`);
+    });
+    it("should handle free form object (1)", () => {
+      const item = {
+        type: "object",
+      };
+      expect(getObject(item)).toMatchInlineSnapshot(`"{[key: string]: any}"`);
+    });
+    it("should handle free form object (2)", () => {
+      const item = {
+        type: "object",
+        additionalProperties: true,
+      };
+      expect(getObject(item)).toMatchInlineSnapshot(`"{[key: string]: any}"`);
+    });
+    it("should handle free form object (3)", () => {
+      const item = {
+        type: "object",
+        additionalProperties: {},
+      };
+      expect(getObject(item)).toMatchInlineSnapshot(`"{[key: string]: any}"`);
     });
   });
 


### PR DESCRIPTION
# Why

To bring a bit of flexibility on the openAPI generator, I would like to introduce a new `customGenerator` for advanced configurations.

This is in response for #226 and #223, I tried a first integration in our product with some `fetch` generator, this works quite well 😃 

I could come with something more easy to use and restrictive, but I want to give a try for more customization. Indeed, everybody project is a bit different (axios, basic fetch, rxjs…) so let's the user come with what he need!

You can have a preview of this PR in `restful-react@canary`

## Todo

- [ ] Add some docs
- [ ] Add an example

## Example from my integration test (to be cleaned and integrated in the PR)

```ts
// restful-react.config.js
customImport: `import { getConfig } from "../../products/IdP/Config"\nimport { customGet, customMutate, CustomGetProps, CustomMutateProps } from "../fetchers"`,
customGenerator: ({ componentName, verb, route, description, genericsTypes, paramsInPath, paramsTypes }) => {
      const propsType = type =>
        `Custom${type}Props<${genericsTypes}>${paramsInPath.length ? ` & {${paramsTypes}}` : ""}`;

      return verb === "get"
        ? `${description}export const ${camel(componentName)} = (${
            paramsInPath.length ? `{${paramsInPath.join(", ")}, ...props}` : "props"
          }: ${propsType("Get")}) => customGet<${genericsTypes}>(getConfig("backend") + \`${route}\`, props);\n\n`
        : `${description}export const ${camel(componentName)} = (${
            paramsInPath.length ? `{${paramsInPath.join(", ")}, ...props}` : "props"
          }: ${propsType(
            "Mutate",
          )}) => customMutate<${genericsTypes}>("${verb.toUpperCase()}", getConfig("backend") + \`${route}\`, props);\n\n`;
    },
```

```ts
// fetchers.ts
import Cookies from "js-cookie";
import qs from "qs";
import { GeneralErrorResponse } from "./hub/hub";

export const errors = {
  401: "401 - Not authorized.",
  500: "500 - Server error.",
  502: "502 - Bad Gateway.",
  503: "503 - Service unavailable.",
  504: "504 - Gateway timeout.",
};

export interface CustomGetProps<
  _TData = any,
  _TError = any,
  TQueryParams = {
    [key: string]: any;
  }
> {
  queryParams?: TQueryParams;
}

export const customGet = <
  TData = any,
  _TError = any,
  TQueryParams = {
    [key: string]: any;
  }
>(
  path: string,
  props: { queryParams?: TQueryParams },
) => {
  let url = path;
  if (props.queryParams && Object.keys(props.queryParams).length) {
    url += `?${qs.stringify(props.queryParams)}`;
  }
  return fetch(url, {
    credentials: "include",
    headers: {
      "x-double-cookie": Cookies.get("double-cookie") || "",
      "content-type": "application/json",
    },
  }).then(res => {
    if ((res.headers.get("content-type") || "").includes("application/json")) {
      return (res.json() as unknown) as TData;
    }

    return {
      errors: [
        {
          type: "GeneralError",
          message: (errors as any)[res.status] || errors[500],
        },
      ],
    } as GeneralErrorResponse;
  });
};

export interface CustomMutateProps<
  _TData = any,
  _TError = any,
  TQueryParams = {
    [key: string]: any;
  },
  TRequestBody = any
> {
  body: TRequestBody;
  queryParams?: TQueryParams;
}

export const customMutate = <
  TData = any,
  _TError = any,
  TQueryParams = {
    [key: string]: any;
  },
  TRequestBody = any
>(
  method: string,
  path: string,
  props: { body: TRequestBody; queryParams?: TQueryParams },
) => {
  let url = path;
  if (method === "DELETE" && typeof props.body === "string") {
    url += `/${props.body}`;
  }
  if (props.queryParams && Object.keys(props.queryParams).length) {
    url += `?${qs.stringify(props.queryParams)}`;
  }
  return fetch(url, {
    method,
    body: JSON.stringify(props.body),
    credentials: "include",
    headers: {
      "x-double-cookie": Cookies.get("double-cookie") || "",
      "content-type": "application/json",
    },
  }).then(res => {
    if ((res.headers.get("content-type") || "").includes("application/json")) {
      return (res.json() as unknown) as TData;
    }

    return {
      errors: [
        {
          type: "GeneralError",
          message: (errors as any)[res.status] || errors[500],
        },
      ],
    } as GeneralErrorResponse;
  });
};

export const isGeneralErrorResponse = (data: any): data is GeneralErrorResponse => {
  return data && Array.isArray(data.errors);
};
```

## Notes

For the crazy people around, this PR could open this generator to everything else than react, angular or vue fan boys, this is for you! 😁 