### PR TITLE
Save token in home instead of node_modules

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "qs": "^6.9.1",
     "react-fast-compare": "^2.0.4",
     "request": "^2.88.0",
+    "slash": "^3.0.0",
     "swagger2openapi": "^5.3.2",
     "tslib": "^1.10.0",
     "url": "^0.11.0",

--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -5,6 +5,8 @@ import inquirer from "inquirer";
 import difference from "lodash/difference";
 import { join, parse } from "path";
 import request from "request";
+import { homedir } from "os";
+import slash from "slash";
 
 import importOpenApi from "../scripts/import-open-api";
 import { OperationObject } from "openapi3-ts";
@@ -122,7 +124,7 @@ const importSpecs = async (options: AdvancedOptions) => {
     const { github } = options;
 
     let accessToken: string;
-    const githubTokenPath = join(__dirname, ".githubToken");
+    const githubTokenPath = join(homedir(), ".restful-react");
     if (existsSync(githubTokenPath)) {
       accessToken = readFileSync(githubTokenPath, "utf-8");
     } else {
@@ -136,7 +138,7 @@ const importSpecs = async (options: AdvancedOptions) => {
         {
           type: "confirm",
           name: "saveToken",
-          message: "Would you like to store your token for the next time? (stored in your node_modules)",
+          message: `Would you like to store your token for the next time? (stored in your ${slash(githubTokenPath)})`,
         },
       ]);
       if (answers.saveToken) {

--- a/src/bin/restful-react-import.ts
+++ b/src/bin/restful-react-import.ts
@@ -133,7 +133,7 @@ const importSpecs = async (options: AdvancedOptions) => {
           type: "input",
           name: "githubToken",
           message:
-            "Please provide a GitHub token with `repo` rules checked (https://help.github.com/articles/creating-a-personal-access-token-for-the-command-line/)",
+            "Please provide a GitHub token with `repo` rules checked ( https://help.github.com/en/github/authenticating-to-github/creating-a-personal-access-token-for-the-command-line )",
         },
         {
           type: "confirm",


### PR DESCRIPTION
# Why

After 1 year of resetting my token at every `npm install`, this is time to fix my initial mistake 😁 

![image](https://user-images.githubusercontent.com/1761469/73726544-0a98a680-4730-11ea-8719-83bccbd180af.png)

Let's store the github token in home, like everybody, it's a token user so it should go in a user scope, not project.
