### PR TITLE
fix: codegen for array of enums

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -101,7 +101,7 @@ export const getRef = ($ref: ReferenceObject["$ref"]) => {
  */
 export const getArray = (item: SchemaObject): string => {
   if (item.items) {
-    if (!isReference(item.items) && (item.items.oneOf || item.items.allOf)) {
+    if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
       return `(${resolveValue(item.items)})[]`;
     } else {
       return `${resolveValue(item.items)}[]`;

--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -52,6 +52,13 @@ export interface Error {
   message: string;
 }
 
+/**
+ * Request description
+ */
+export interface Request {
+  action?: (\\"create\\" | \\"read\\" | \\"update\\" | \\"delete\\")[];
+}
+
 export type UpdatePetRequestRequestBody = NewPet;
 
 export interface FindPetsQueryParams {

--- a/src/scripts/tests/petstore-expanded.yaml
+++ b/src/scripts/tests/petstore-expanded.yaml
@@ -232,3 +232,15 @@ components:
           format: int32
         message:
           type: string
+    Request:
+      description: Request description
+      properties:
+        action:
+          type: array
+          items:
+            type: string
+            enum:
+              - create
+              - read
+              - update
+              - delete


### PR DESCRIPTION
# Why

<!-- Why did you make this PR? What problem does it solve? -->
For the following object
```yml
Request:
  properties:
    actions:
      type: array
      items:
        type: string
        enum:
          - create
          - view
          - update
          - delete
```
produces

```ts
interface Request {
  actions: 'create' | 'view' | 'update' | 'delete''[]
}
```

but expected result is

```ts
interface Request {
  actions: ('create' | 'view' | 'update' | 'delete'')[]
}
```
