### PR TITLE
Added onRequest & onResponse in RestfulProvider

### DIFF
--- a/README.md
+++ b/README.md
@@ -177,6 +177,14 @@ export interface RestfulReactProviderProps<T = any> {
    * to deal with your retry locally instead of in the provider scope.
    */
   onError?: (err: any, retry: () => Promise<T | null>, response?: Response) => void;
+  /**
+   * Trigger on each request.
+   */
+  onRequest?: (req: Request) => void;
+  /**
+   * Trigger on each response.
+   */
+  onResponse?: (req: Response) => void;
 }
 
 // Usage

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -36,6 +36,14 @@ export interface RestfulReactProviderProps<TData = any> {
     response?: Response,
   ) => void;
   /**
+   * Trigger on each request
+   */
+  onRequest?: (req: Request) => void;
+  /**
+   * Trigger on each response
+   */
+  onResponse?: (res: Response) => void;
+  /**
    * Any global level query params?
    * **Warning:** it's probably not a good idea to put API keys here. Consider headers instead.
    */
@@ -48,11 +56,15 @@ export const Context = React.createContext<Required<RestfulReactProviderProps>>(
   resolve: (data: any) => data,
   requestOptions: {},
   onError: noop,
+  onRequest: noop,
+  onResponse: noop,
   queryParams: {},
 });
 
 export interface InjectedProps {
   onError: RestfulReactProviderProps["onError"];
+  onRequest: RestfulReactProviderProps["onRequest"];
+  onResponse: RestfulReactProviderProps["onResponse"];
 }
 
 export default class RestfulReactProvider<T> extends React.Component<RestfulReactProviderProps<T>> {
@@ -64,6 +76,8 @@ export default class RestfulReactProvider<T> extends React.Component<RestfulReac
       <Context.Provider
         value={{
           onError: noop,
+          onRequest: noop,
+          onResponse: noop,
           resolve: (data: any) => data,
           requestOptions: {},
           parentPath: "",

--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -130,6 +130,49 @@ describe("Get", () => {
       requestResolves!();
       await wait(() => expect(resolve).not.toHaveBeenCalled());
     });
+
+    it("should call the provider onRequest", async () => {
+      const path = "https://my-awesome-api.fake";
+      nock(path)
+        .get("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onRequest = jest.fn();
+      const request = new Request(path);
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onRequest={onRequest}>
+          <Get path="">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(onRequest).toBeCalledWith(request);
+    });
+
+    it("should call the provider onResponse", async () => {
+      const path = "https://my-awesome-api.fake";
+      nock(path)
+        .get("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onResponse = jest.fn();
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onResponse={onResponse}>
+          <Get path="">{children}</Get>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(onResponse).toBeCalled();
+    });
   });
 
   describe("with error", () => {

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -235,7 +235,8 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
   };
 
   public fetch = async (requestPath?: string, thisRequestOptions?: RequestInit) => {
-    const { base, __internal_hasExplicitBase, parentPath, path, resolve } = this.props;
+    const { base, __internal_hasExplicitBase, parentPath, path, resolve, onError, onRequest, onResponse } = this.props;
+
     if (this.state.error || !this.state.loading) {
       this.setState(() => ({ error: null, loading: true }));
     }
@@ -256,9 +257,11 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
     };
 
     const request = new Request(makeRequestPath(), await this.getRequestOptions(thisRequestOptions));
+    if (onRequest) onRequest(request);
     try {
       const response = await fetch(request, { signal: this.signal });
       const { data, responseError } = await processResponse(response);
+      if (onResponse) onResponse(response);
 
       // avoid state updates when component has been unmounted
       if (this.signal.aborted) {
@@ -277,8 +280,8 @@ class ContextlessGet<TData, TError, TQueryParams> extends React.Component<
           error,
         });
 
-        if (!this.props.localErrorOnly && this.props.onError) {
-          this.props.onError(error, () => this.fetch(requestPath, thisRequestOptions), response);
+        if (!this.props.localErrorOnly && onError) {
+          onError(error, () => this.fetch(requestPath, thisRequestOptions), response);
         }
 
         return null;

--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -902,5 +902,83 @@ describe("Mutate", () => {
       // after post state
       expect(children.mock.calls[2][1].loading).toEqual(false);
     });
+
+    it("should call the provider onRequest", async () => {
+      const path = "https://my-awesome-api.fake";
+      nock(path)
+        .post("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onRequest = jest.fn();
+      const request = new Request(path, {
+        method: "POST",
+        headers: { "content-type": "text/plain" },
+      });
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onRequest={onRequest}>
+          <Mutate<void, void, void> verb="POST" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // post action
+      children.mock.calls[0][0]();
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after post state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+
+      // expect onRequest to be called
+      expect(onRequest).toBeCalledWith(request);
+    });
+
+    it("should call the provider onResponse", async () => {
+      const path = "https://my-awesome-api.fake";
+      nock(path)
+        .post("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onResponse = jest.fn();
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onResponse={onResponse}>
+          <Mutate<void, void, void> verb="POST" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // post action
+      children.mock.calls[0][0]();
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after post state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+
+      // expect onResponse to be called
+      expect(onResponse).toBeCalled();
+    });
   });
 });

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -134,6 +134,9 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
       path,
       verb,
       requestOptions: providerRequestOptions,
+      onError,
+      onRequest,
+      onResponse,
     } = this.props;
     this.setState(() => ({ error: null, loading: true }));
 
@@ -171,10 +174,12 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
         ...(mutateRequestOptions ? mutateRequestOptions.headers : {}),
       },
     } as RequestInit); // Type assertion for version of TypeScript that can't yet discriminate.
+    if (onRequest) onRequest(request);
 
     let response: Response;
     try {
       response = await fetch(request, { signal: this.signal });
+      if (onResponse) onResponse(response);
     } catch (e) {
       const error = {
         message: `Failed to fetch: ${e.message}`,
@@ -186,8 +191,8 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
         loading: false,
       });
 
-      if (!this.props.localErrorOnly && this.props.onError) {
-        this.props.onError(error, () => this.mutate(body, mutateRequestOptions));
+      if (!this.props.localErrorOnly && onError) {
+        onError(error, () => this.mutate(body, mutateRequestOptions));
       }
 
       throw error;
@@ -211,8 +216,8 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody> extends React
         loading: false,
       });
 
-      if (!this.props.localErrorOnly && this.props.onError) {
-        this.props.onError(error, () => this.mutate(body, mutateRequestOptions), response);
+      if (!this.props.localErrorOnly && onError) {
+        onError(error, () => this.mutate(body, mutateRequestOptions), response);
       }
 
       throw error;

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -389,6 +389,49 @@ describe("Poll", () => {
 
       await wait(() => expect(children.mock.calls.length).toBe(2));
     });
+
+    it("should call the provider onRequest", async () => {
+      const path = "https://my-awesome-api.fake";
+      nock(path)
+        .get("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onRequest = jest.fn();
+      const request = new Request(path, { headers: { prefer: "wait=60s;" } });
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onRequest={onRequest}>
+          <Poll path="">{children}</Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(onRequest).toBeCalledWith(request);
+    });
+
+    it("should call the provider onResponse", async () => {
+      const path = "https://my-awesome-api.fake";
+      nock(path)
+        .get("/")
+        .reply(200, { hello: "world" });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      const onResponse = jest.fn();
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onResponse={onResponse}>
+          <Poll path="">{children}</Poll>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(2));
+      expect(onResponse).toBeCalled();
+    });
   });
 
   describe("with error", () => {

--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -113,6 +113,52 @@ describe("useGet hook", () => {
       requestResolves!();
       await wait(() => expect(resolve).not.toHaveBeenCalled());
     });
+
+    it("should call provider onRequest", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { oh: "my god 😍" });
+
+      const MyAwesomeComponent = () => {
+        const { data, loading } = useGet<{ oh: string }>({ path: "/" });
+
+        return loading ? <div data-testid="loading">Loading…</div> : <div data-testid="data">{data?.oh}</div>;
+      };
+
+      const onRequest = jest.fn();
+
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake" onRequest={onRequest}>
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      expect(onRequest).toBeCalled();
+    });
+
+    it("should call provider onResponse", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { oh: "my god 😍" });
+
+      const MyAwesomeComponent = () => {
+        const { data, loading } = useGet<{ oh: string }>({ path: "/" });
+
+        return loading ? <div data-testid="loading">Loading…</div> : <div data-testid="data">{data?.oh}</div>;
+      };
+
+      const onResponse = jest.fn();
+
+      const { getByTestId } = render(
+        <RestfulProvider base="https://my-awesome-api.fake" onResponse={onResponse}>
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      await waitForElement(() => getByTestId("data"));
+
+      expect(onResponse).toBeCalled();
+    });
   });
 
   describe("url composition", () =>

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -107,10 +107,12 @@ async function _fetchData<TData, TError, TQueryParams>(
     resolvePath(base, path, { ...context.queryParams, ...queryParams }, props.queryParamStringifyOptions || {}),
     merge({}, contextRequestOptions, requestOptions, { signal }),
   );
+  if (context.onRequest) context.onRequest(request);
 
   try {
     const response = await fetch(request);
     const { data, responseError } = await processResponse(response);
+    if (context.onResponse) context.onResponse(response);
 
     if (signal && signal.aborted) {
       return;

--- a/src/useMutate.test.tsx
+++ b/src/useMutate.test.tsx
@@ -510,6 +510,38 @@ describe("useMutate", () => {
         expect(e.message).toEqual("I don't like your data!");
       }
     });
+
+    it("should call the provider onRequest", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .reply(200, { hello: "world" });
+
+      const onRequest = jest.fn();
+      const wrapper: React.FC = ({ children }) => (
+        <RestfulProvider base="https://my-awesome-api.fake" onRequest={onRequest}>
+          {children}
+        </RestfulProvider>
+      );
+      const { result } = renderHook(() => useMutate("POST", ""), { wrapper });
+      await result.current.mutate({ foo: "bar" });
+      expect(onRequest).toBeCalled();
+    });
+
+    it("should call the provider onResponse", async () => {
+      nock("https://my-awesome-api.fake")
+        .post("/")
+        .reply(200, { hello: "world" });
+
+      const onResponse = jest.fn();
+      const wrapper: React.FC = ({ children }) => (
+        <RestfulProvider base="https://my-awesome-api.fake" onResponse={onResponse}>
+          {children}
+        </RestfulProvider>
+      );
+      const { result } = renderHook(() => useMutate("POST", ""), { wrapper });
+      await result.current.mutate({ foo: "bar" });
+      expect(onResponse).toBeCalled();
+    });
   });
 
   describe("generation pattern", () => {

--- a/src/useMutate.tsx
+++ b/src/useMutate.tsx
@@ -104,10 +104,12 @@ export function useMutate<
         ),
         merge({}, contextRequestOptions, options, propsRequestOptions, mutateRequestOptions, { signal }),
       );
+      if (context.onRequest) context.onRequest(request);
 
       let response: Response;
       try {
         response = await fetch(request);
+        if (context.onResponse) context.onResponse(response);
       } catch (e) {
         const error = {
           message: `Failed to fetch: ${e.message}`,


### PR DESCRIPTION
# Why

## Problem
I have a problem with handling some global actions with request and response to handle refresh token on authentication cycle, for example I need to check on every request if the access token is expired or not and replace the Authorization header value with refresh token instead of the access token and on the response of this request I need to get the new access token and save it globally.

## Solution
Added two new triggers **onRequest**, **onResponse** like **onError** trigger and added call for these triggers when initializing the request and when get a new response on all library components and hooks.

## Use Cases
- handle any staff needed to be handled globally depend on request or response objects.
- listen to all requests and responses globally for debugging and logging purposes.
- I guess this PR has a possible solution for these three issues #171, #172, #173

Thank you for your great library and your great effort :pray: 