### PR TITLE
#261 - processResponse support blob & Co

### DIFF
--- a/src/Get.test.tsx
+++ b/src/Get.test.tsx
@@ -500,7 +500,7 @@ describe("Get", () => {
     it("should render if we have an error", async () => {
       nock("https://my-awesome-api.fake")
         .get("/")
-        .reply(401, "Go away!");
+        .reply(401, "Go away!", { "content-type": "text/plain" });
 
       const children = jest.fn();
       children.mockReturnValue(<div />);

--- a/src/Poll.test.tsx
+++ b/src/Poll.test.tsx
@@ -498,7 +498,7 @@ describe("Poll", () => {
         },
       })
         .get("/")
-        .reply(200, { data: "hello" }, { "x-polling-index": "1" });
+        .reply(200, { data: "hello" }, { "x-polling-index": "1", "content-type": "application/json" });
 
       const children = jest.fn();
       children.mockReturnValue(<div />);

--- a/src/util/processResponse.ts
+++ b/src/util/processResponse.ts
@@ -14,9 +14,21 @@ export const processResponse = async (response: Response) => {
         responseError: true,
       };
     }
+  } else if ((response.headers.get("content-type") || "").includes("text/plain")) {
+    try {
+      return {
+        data: await response.text(),
+        responseError: false,
+      };
+    } catch (e) {
+      return {
+        data: e.message,
+        responseError: true,
+      };
+    }
   } else {
     return {
-      data: await response.text(),
+      data: response,
       responseError: false,
     };
   }

--- a/src/util/processResponse.ts
+++ b/src/util/processResponse.ts
@@ -14,7 +14,10 @@ export const processResponse = async (response: Response) => {
         responseError: true,
       };
     }
-  } else if ((response.headers.get("content-type") || "").includes("text/plain")) {
+  } else if (
+    (response.headers.get("content-type") || "").includes("text/plain") ||
+    (response.headers.get("content-type") || "").includes("text/html")
+  ) {
     try {
       return {
         data: await response.text(),


### PR DESCRIPTION
- if the content-type is "application/json" or "text/plain" behavior will not change.
- all other cases will return whole response object.

# Why
See: https://github.com/contiamo/restful-react/issues/261