### PR TITLE
Add mocks support

### DIFF
--- a/README.md
+++ b/README.md
@@ -422,6 +422,50 @@ export default MyHugeList;
 
 Each mutation returns a promise that can then be used to update local component state, dispatch an action, or do something else depending on your use case.
 
+### Mocks
+
+No backend support yet for your amazing feature? Need to isolate an edge case? You can easily provide a mock to `useMutate` and `useGet` to bypass the classic flow.
+
+/!\ If `mocks` option is provided, no requests will be send to the server. /!\
+
+```jsx
+import React from "react";
+import { useGet, useMutate } from "restful-react";
+
+const base = "https://jsonplaceholder.typicode.com";
+
+// Mock the `mutate` handler
+const { mutate: del, loading } = useMutate({
+  verb: "DELETE",
+  path: `/posts/`,
+  base,
+  // This will avoid any server call in favor of mock response
+  mocks: {
+    mutate: id => console.log(`The item ${id} was deleted`),
+  },
+});
+
+// Mock the `loading`, so it's easy to isolate the loading state
+const { data: posts } = useGet({
+  path: "/posts",
+  base,
+  // This will avoid any server call in favor of mock response
+  mocks: {
+    loading: true,
+  },
+});
+
+// Mock the `error`, so it's easy to isolate the error state
+const { data: posts } = useGet({
+  path: "/posts",
+  base,
+  // This will avoid any server call in favor of mock response
+  mocks: {
+    error: "oh no!",
+  },
+});
+```
+
 ### Polling with `Poll`
 
 `restful-react` also exports a `Poll` render props component that will poll a backend endpoint over a predetermined interval until a stop condition is met. Consider,

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -489,7 +489,7 @@ ${description}export const use${componentName} = (${
     verb === "get" ? "" : `"${verb.toUpperCase()}", `
   }${
     paramsInPath.length
-      ? `({ ${paramsInPath.join(", ")} }: ${componentName}PathParams) => \`${route}\``
+      ? `(paramsInPath: ${componentName}PathParams) => \`${route.replace(/\$\{/g, "${paramsInPath.")}\``
       : `\`${route}\``
   }, ${
     customPropsEntries.length || paramsInPath.length

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -548,7 +548,10 @@ export const Poll${componentName} = (${
  */
 export const generateInterface = (name: string, schema: SchemaObject) => {
   const scalar = getScalar(schema);
-  return `${formatDescription(schema.description)}export interface ${pascal(name)} ${scalar}`;
+  const isEmptyInterface = scalar === "{}";
+  return `${formatDescription(schema.description)}${
+    isEmptyInterface ? "// tslint:disable-next-line:no-empty-interface\n" : ""
+  }export interface ${pascal(name)} ${scalar}`;
 };
 
 /**

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -402,10 +402,10 @@ export const generateRestfulComponent = (
 
   const genericsTypesForHooksProps =
     verb === "get"
-      ? `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${
+      ? `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${errorTypes}, ${
           queryParamsType ? componentName + "QueryParams" : "void"
         }, ${paramsInPath.length ? componentName + "PathParams" : "void"}`
-      : `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${
+      : `${needAResponseComponent ? componentName + "Response" : responseTypes}, ${errorTypes}, ${
           queryParamsType ? componentName + "QueryParams" : "void"
         }, ${
           verb === "delete" && lastParamInTheRoute

--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -145,7 +145,7 @@ export type UseFindPetByIdProps = Omit<UseGetProps<Pet, Error, void, FindPetById
 /**
  * Returns a user based on a single ID, if the user does not have access to the pet
  */
-export const useFindPetById = ({id, ...props}: UseFindPetByIdProps) => useGet<Pet, Error, void, FindPetByIdPathParams>(({ id }: FindPetByIdPathParams) => \`/pets/\${id}\`, { pathParams: { id }, ...props });
+export const useFindPetById = ({id, ...props}: UseFindPetByIdProps) => useGet<Pet, Error, void, FindPetByIdPathParams>((paramsInPath: FindPetByIdPathParams) => \`/pets/\${paramsInPath.id}\`, { pathParams: { id }, ...props });
 
 
 export type DeletePetProps = Omit<MutateProps<void, Error, void, number, void>, \\"path\\" | \\"verb\\">;
@@ -194,7 +194,7 @@ export type UseUpdatePetProps = Omit<UseMutateProps<Pet, Error, void, UpdatePetR
 /**
  * Updates a pet in the store.
  */
-export const useUpdatePet = ({id, ...props}: UseUpdatePetProps) => useMutate<Pet, Error, void, UpdatePetRequestRequestBody, UpdatePetPathParams>(\\"PATCH\\", ({ id }: UpdatePetPathParams) => \`/pets/\${id}\`, { pathParams: { id }, ...props });
+export const useUpdatePet = ({id, ...props}: UseUpdatePetProps) => useMutate<Pet, Error, void, UpdatePetRequestRequestBody, UpdatePetPathParams>(\\"PATCH\\", (paramsInPath: UpdatePetPathParams) => \`/pets/\${paramsInPath.id}\`, { pathParams: { id }, ...props });
 
 "
 `;

--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -88,7 +88,7 @@ export const FindPets = (props: FindPetsProps) => (
   />
 );
 
-export type UseFindPetsProps = Omit<UseGetProps<Pet[], FindPetsQueryParams, void>, \\"path\\">;
+export type UseFindPetsProps = Omit<UseGetProps<Pet[], Error, FindPetsQueryParams, void>, \\"path\\">;
 
 /**
  * Returns all pets from the system that the user has access to
@@ -113,7 +113,7 @@ export const AddPet = (props: AddPetProps) => (
   />
 );
 
-export type UseAddPetProps = Omit<UseMutateProps<Pet, void, NewPet, void>, \\"path\\" | \\"verb\\">;
+export type UseAddPetProps = Omit<UseMutateProps<Pet, Error, void, NewPet, void>, \\"path\\" | \\"verb\\">;
 
 /**
  * Creates a new pet in the store.  Duplicates are allowed
@@ -140,7 +140,7 @@ export const FindPetById = ({id, ...props}: FindPetByIdProps) => (
   />
 );
 
-export type UseFindPetByIdProps = Omit<UseGetProps<Pet, void, FindPetByIdPathParams>, \\"path\\"> & FindPetByIdPathParams;
+export type UseFindPetByIdProps = Omit<UseGetProps<Pet, Error, void, FindPetByIdPathParams>, \\"path\\"> & FindPetByIdPathParams;
 
 /**
  * Returns a user based on a single ID, if the user does not have access to the pet
@@ -161,7 +161,7 @@ export const DeletePet = (props: DeletePetProps) => (
   />
 );
 
-export type UseDeletePetProps = Omit<UseMutateProps<void, void, number, void>, \\"path\\" | \\"verb\\">;
+export type UseDeletePetProps = Omit<UseMutateProps<void, Error, void, number, void>, \\"path\\" | \\"verb\\">;
 
 /**
  * deletes a single pet based on the ID supplied
@@ -189,7 +189,7 @@ export const UpdatePet = ({id, ...props}: UpdatePetProps) => (
   />
 );
 
-export type UseUpdatePetProps = Omit<UseMutateProps<Pet, void, UpdatePetRequestRequestBody, UpdatePetPathParams>, \\"path\\" | \\"verb\\"> & UpdatePetPathParams;
+export type UseUpdatePetProps = Omit<UseMutateProps<Pet, Error, void, UpdatePetRequestRequestBody, UpdatePetPathParams>, \\"path\\" | \\"verb\\"> & UpdatePetPathParams;
 
 /**
  * Updates a pet in the store.

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -870,7 +870,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, void, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -911,7 +911,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, unknown, void, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -951,7 +951,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, unknown, void, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -1002,7 +1002,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, void, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -1079,7 +1079,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, ListFieldsQueryParams, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -1162,7 +1162,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, ListFieldsQueryParams, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, ListFieldsQueryParams, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -1236,7 +1236,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, ListFieldsPathParams>, \\"path\\"> & ListFieldsPathParams;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, void, ListFieldsPathParams>, \\"path\\"> & ListFieldsPathParams;
 
         /**
          * List all fields for the use case schema
@@ -1317,7 +1317,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, ListFieldsPathParams>, \\"path\\"> & ListFieldsPathParams;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, void, ListFieldsPathParams>, \\"path\\"> & ListFieldsPathParams;
 
         /**
          * List all fields for the use case schema
@@ -1392,7 +1392,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UseCaseInstance, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
 
         /**
          * Update use case details
@@ -1484,7 +1484,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, void, UpdateUseCaseRequestBody, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UseCaseResponse, APIError, void, UpdateUseCaseRequestBody, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
 
         /**
          * Update use case details
@@ -1579,7 +1579,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
 
         /**
          * Update use case details
@@ -1677,7 +1677,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, void, UseCaseInstance, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
+        export type UseUpdateUseCaseProps = Omit<UseMutateProps<UpdateUseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>, \\"path\\" | \\"verb\\"> & UpdateUseCasePathParams;
 
         /**
          * Update use case details
@@ -1740,7 +1740,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, string, void>, \\"path\\" | \\"verb\\">;
+        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, APIError, void, string, void>, \\"path\\" | \\"verb\\">;
 
         /**
          * Delete use case
@@ -1809,7 +1809,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, void, DeleteUseCasePathParams>, \\"path\\" | \\"verb\\"> & DeleteUseCasePathParams;
+        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, APIError, void, void, DeleteUseCasePathParams>, \\"path\\" | \\"verb\\"> & DeleteUseCasePathParams;
 
         /**
          * Delete use case
@@ -1872,7 +1872,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, number, void>, \\"path\\" | \\"verb\\">;
+        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, APIError, void, number, void>, \\"path\\" | \\"verb\\">;
 
         /**
          * Delete use case
@@ -1930,7 +1930,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, void, UseCaseId, void>, \\"path\\" | \\"verb\\">;
+        export type UseDeleteUseCaseProps = Omit<UseMutateProps<void, APIError, void, UseCaseId, void>, \\"path\\" | \\"verb\\">;
 
         /**
          * Delete use case
@@ -1986,7 +1986,7 @@ describe("scripts/import-open-api", () => {
           />
         );
 
-        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, void, void>, \\"path\\">;
+        export type UseListFieldsProps = Omit<UseGetProps<FieldListResponse, APIError, void, void>, \\"path\\">;
 
         /**
          * List all fields for the use case schema
@@ -2041,7 +2041,7 @@ describe("scripts/import-open-api", () => {
         />
       );
 
-      export type UseListFieldsProps = Omit<UseGetProps<void, void, void>, \\"path\\">;
+      export type UseListFieldsProps = Omit<UseGetProps<void, APIError, void, void>, \\"path\\">;
 
       /**
        * List all fields for the use case schema

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -583,6 +583,19 @@ describe("scripts/import-open-api", () => {
 
       expect(generateSchemasDefinition(schema)).toContain(`export type Wolf = Dog;`);
     });
+
+    it("should deal with empty object", () => {
+      const schema = {
+        Wolf: {
+          type: "object",
+          properties: {},
+          additionalProperties: false,
+        },
+      };
+
+      expect(generateSchemasDefinition(schema)).toContain(`// tslint:disable-next-line:no-empty-interface`);
+      expect(generateSchemasDefinition(schema)).toContain(`export interface Wolf {}`);
+    });
   });
 
   describe("generateResponsesDefinition", () => {

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -1241,7 +1241,7 @@ describe("scripts/import-open-api", () => {
         /**
          * List all fields for the use case schema
          */
-        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void, ListFieldsPathParams>(({ id }: ListFieldsPathParams) => \`/fields/\${id}\`, { pathParams: { id }, ...props });
+        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void, ListFieldsPathParams>((paramsInPath: ListFieldsPathParams) => \`/fields/\${paramsInPath.id}\`, { pathParams: { id }, ...props });
 
         "
       `);
@@ -1322,7 +1322,7 @@ describe("scripts/import-open-api", () => {
         /**
          * List all fields for the use case schema
          */
-        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void, ListFieldsPathParams>(({ id }: ListFieldsPathParams) => \`/fields/\${id}\`, { pathParams: { id }, ...props });
+        export const useListFields = ({id, ...props}: UseListFieldsProps) => useGet<FieldListResponse, APIError, void, ListFieldsPathParams>((paramsInPath: ListFieldsPathParams) => \`/fields/\${paramsInPath.id}\`, { pathParams: { id }, ...props });
 
         "
       `);
@@ -1397,7 +1397,7 @@ describe("scripts/import-open-api", () => {
         /**
          * Update use case details
          */
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>(\\"PUT\\", ({ useCaseId }: UpdateUseCasePathParams) => \`/use-cases/\${useCaseId}\`, { pathParams: { useCaseId }, ...props });
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>(\\"PUT\\", (paramsInPath: UpdateUseCasePathParams) => \`/use-cases/\${paramsInPath.useCaseId}\`, { pathParams: { useCaseId }, ...props });
 
         "
       `);
@@ -1489,7 +1489,7 @@ describe("scripts/import-open-api", () => {
         /**
          * Update use case details
          */
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UpdateUseCaseRequestBody, UpdateUseCasePathParams>(\\"PUT\\", ({ useCaseId }: UpdateUseCasePathParams) => \`/use-cases/\${useCaseId}\`, { pathParams: { useCaseId }, ...props });
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UseCaseResponse, APIError, void, UpdateUseCaseRequestBody, UpdateUseCasePathParams>(\\"PUT\\", (paramsInPath: UpdateUseCasePathParams) => \`/use-cases/\${paramsInPath.useCaseId}\`, { pathParams: { useCaseId }, ...props });
 
         "
       `);
@@ -1584,7 +1584,7 @@ describe("scripts/import-open-api", () => {
         /**
          * Update use case details
          */
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>(\\"PUT\\", ({ useCaseId }: UpdateUseCasePathParams) => \`/use-cases/\${useCaseId}\`, { pathParams: { useCaseId }, ...props });
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>(\\"PUT\\", (paramsInPath: UpdateUseCasePathParams) => \`/use-cases/\${paramsInPath.useCaseId}\`, { pathParams: { useCaseId }, ...props });
 
         "
       `);
@@ -1682,7 +1682,7 @@ describe("scripts/import-open-api", () => {
         /**
          * Update use case details
          */
-        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>(\\"PUT\\", ({ useCaseId }: UpdateUseCasePathParams) => \`/use-cases/\${useCaseId}\`, { pathParams: { useCaseId }, ...props });
+        export const useUpdateUseCase = ({useCaseId, ...props}: UseUpdateUseCaseProps) => useMutate<UpdateUseCaseResponse, APIError, void, UseCaseInstance, UpdateUseCasePathParams>(\\"PUT\\", (paramsInPath: UpdateUseCasePathParams) => \`/use-cases/\${paramsInPath.useCaseId}\`, { pathParams: { useCaseId }, ...props });
 
         "
       `);
@@ -1814,7 +1814,7 @@ describe("scripts/import-open-api", () => {
         /**
          * Delete use case
          */
-        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void, DeleteUseCasePathParams>(\\"DELETE\\", ({ useCaseId }: DeleteUseCasePathParams) => \`/use-cases/\${useCaseId}/secret\`, { pathParams: { useCaseId }, ...props });
+        export const useDeleteUseCase = ({useCaseId, ...props}: UseDeleteUseCaseProps) => useMutate<void, APIError, void, void, DeleteUseCasePathParams>(\\"DELETE\\", (paramsInPath: DeleteUseCasePathParams) => \`/use-cases/\${paramsInPath.useCaseId}/secret\`, { pathParams: { useCaseId }, ...props });
 
         "
       `);

--- a/src/useMutate.test.tsx
+++ b/src/useMutate.test.tsx
@@ -647,11 +647,11 @@ describe("useMutate", () => {
       }
 
       type UseDeleteMyCustomEndpoint = Omit<
-        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointQueryParams, {}, {}>,
+        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointError, MyCustomEnpointQueryParams, {}, {}>,
         "path" | "verb"
       >;
       const useDeleteMyCustomEndpoint = (props?: UseDeleteMyCustomEndpoint) =>
-        useMutate<MyCustomEnpointResponse, MyCustomEnpointError, MyCustomEnpointQueryParams, string>(
+        useMutate<MyCustomEnpointResponse, MyCustomEnpointError, MyCustomEnpointQueryParams, string, {}>(
           "DELETE",
           "",
           props,
@@ -694,11 +694,11 @@ describe("useMutate", () => {
       }
 
       type UseDeleteMyCustomEndpoint = Omit<
-        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointQueryParams, {}, {}>,
+        UseMutateProps<MyCustomEnpointResponse, MyCustomEnpointError, MyCustomEnpointQueryParams, {}, {}>,
         "path" | "verb"
       >;
       const useDeleteMyCustomEndpoint = (props?: UseDeleteMyCustomEndpoint) =>
-        useMutate<MyCustomEnpointResponse, MyCustomEnpointError, MyCustomEnpointQueryParams, MyCustomEndpointBody>(
+        useMutate<MyCustomEnpointResponse, MyCustomEnpointError, MyCustomEnpointQueryParams, MyCustomEndpointBody, {}>(
           "POST",
           "plop",
           props,

--- a/src/useMutate.tsx
+++ b/src/useMutate.tsx
@@ -6,8 +6,8 @@ import { Omit, resolvePath, UseGetProps } from "./useGet";
 import { processResponse } from "./util/processResponse";
 import { useAbort } from "./useAbort";
 
-export interface UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams>
-  extends Omit<UseGetProps<TData, TQueryParams, TPathParams>, "lazy" | "debounce"> {
+export interface UseMutateProps<TData, TError, TQueryParams, TRequestBody, TPathParams>
+  extends Omit<UseGetProps<TData, TError, TQueryParams, TPathParams>, "lazy" | "debounce" | "mock"> {
   /**
    * What HTTP verb are we using?
    */
@@ -19,6 +19,14 @@ export interface UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams>
    * @param data - Response data
    */
   onMutate?: (body: TRequestBody, data: TData) => void;
+  /**
+   * Developer mode
+   * Override the state with some mocks values and avoid to fetch
+   */
+  mock?: {
+    mutate?: MutateMethod<TData, TRequestBody, TQueryParams, TPathParams>;
+    loading?: boolean;
+  };
 }
 
 export interface UseMutateReturn<TData, TError, TRequestBody, TQueryParams, TPathParams>
@@ -40,7 +48,7 @@ export function useMutate<
   TRequestBody = any,
   TPathParams = unknown
 >(
-  props: UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams>,
+  props: UseMutateProps<TData, TError, TQueryParams, TRequestBody, TPathParams>,
 ): UseMutateReturn<TData, TError, TRequestBody, TQueryParams, TPathParams>;
 
 export function useMutate<
@@ -50,9 +58,9 @@ export function useMutate<
   TRequestBody = any,
   TPathParams = unknown
 >(
-  verb: UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams>["verb"],
-  path: UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams>["path"],
-  props?: Omit<UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams>, "path" | "verb">,
+  verb: UseMutateProps<TData, TError, TQueryParams, TRequestBody, TPathParams>["verb"],
+  path: UseMutateProps<TData, TError, TQueryParams, TRequestBody, TPathParams>["path"],
+  props?: Omit<UseMutateProps<TData, TError, TQueryParams, TRequestBody, TPathParams>, "path" | "verb">,
 ): UseMutateReturn<TData, TError, TRequestBody, TQueryParams, TPathParams>;
 
 export function useMutate<
@@ -62,7 +70,7 @@ export function useMutate<
   TRequestBody = any,
   TPathParams = unknown
 >(): UseMutateReturn<TData, TError, TRequestBody, TQueryParams, TPathParams> {
-  const props: UseMutateProps<TData, TQueryParams, TRequestBody, TPathParams> =
+  const props: UseMutateProps<TData, TError, TQueryParams, TRequestBody, TPathParams> =
     typeof arguments[0] === "object" ? arguments[0] : { ...arguments[2], path: arguments[1], verb: arguments[0] };
 
   const context = useContext(Context);
@@ -217,6 +225,7 @@ export function useMutate<
   return {
     ...state,
     mutate,
+    ...props.mock,
     cancel: () => {
       setState(prevState => ({
         ...prevState,


### PR DESCRIPTION
# Why

Add `mock` props in `useGet` and `useMutate` to provide an easy way to mock an api call (with type-safety)

More information in the `README.md` of this PR
