### PR TITLE
Rework mutation error and data handling

### DIFF
--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -1,8 +1,8 @@
 import noop from "lodash/noop";
 import * as React from "react";
-import { ResolveFunction } from "./Get";
+import { ResolveFunction, GetDataError } from "./types";
 
-export interface RestfulReactProviderProps<TData = any> {
+export interface RestfulReactProviderProps<TData = any, TError = TData> {
   /** The backend URL where the RESTful resources live. */
   base: string;
   /**
@@ -26,15 +26,7 @@ export interface RestfulReactProviderProps<TData = any> {
    * Depending of your case, it can be easier to add a `localErrorOnly` on your `Mutate` component
    * to deal with your retry locally instead of in the provider scope.
    */
-  onError?: (
-    err: {
-      message: string;
-      data: TData | string;
-      status?: number;
-    },
-    retry: () => Promise<TData | null>,
-    response?: Response,
-  ) => void;
+  onError?: (err: GetDataError<TError>, retry: () => Promise<TData | null>, response?: Response) => void;
   /**
    * Trigger on each request
    */
@@ -53,7 +45,7 @@ export interface RestfulReactProviderProps<TData = any> {
 export const Context = React.createContext<Required<RestfulReactProviderProps>>({
   base: "",
   parentPath: "",
-  resolve: (data: any) => data,
+  resolve: data => data,
   requestOptions: {},
   onError: noop,
   onRequest: noop,
@@ -78,7 +70,7 @@ export default class RestfulReactProvider<T> extends React.Component<RestfulReac
           onError: noop,
           onRequest: noop,
           onResponse: noop,
-          resolve: (data: any) => data,
+          resolve: data => data,
           requestOptions: {},
           parentPath: "",
           queryParams: value.queryParams || {},

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -8,18 +8,7 @@ import RestfulReactProvider, { InjectedProps, RestfulReactConsumer, RestfulReact
 import { composePath, composeUrl } from "./util/composeUrl";
 import { processResponse } from "./util/processResponse";
 import { resolveData } from "./util/resolveData";
-
-/**
- * A function that resolves returned data from
- * a fetch call.
- */
-export type ResolveFunction<TData> = (data: any) => TData;
-
-export interface GetDataError<TError> {
-  message: string;
-  data: TError | string;
-  status?: number;
-}
+import { ResolveFunction, GetDataError } from "./types";
 
 /**
  * An enumeration of states that a fetchable

--- a/src/Poll.tsx
+++ b/src/Poll.tsx
@@ -7,6 +7,7 @@ import { InjectedProps, RestfulReactConsumer } from "./Context";
 import { GetProps, GetState, Meta as GetComponentMeta } from "./Get";
 import { composeUrl } from "./util/composeUrl";
 import { processResponse } from "./util/processResponse";
+import { PollResolveFunction } from "./types";
 
 /**
  * Meta information returned from the poll.
@@ -93,7 +94,7 @@ export interface PollProps<TData, TError, TQueryParams, TPathParams> {
   /**
    * Should the data be transformed in any way?
    */
-  resolve?: (data: any, prevData: TData | null) => TData;
+  resolve?: PollResolveFunction<TData>;
   /**
    * We can request foreign URLs with this prop.
    */
@@ -334,7 +335,11 @@ class ContextlessPoll<TData, TError, TQueryParams, TPathParams = unknown> extend
       start: this.start,
     };
     // data is parsed only when poll has already resolved so response is defined
-    const resolvedData = response && resolve ? resolve(data, previousData) : data;
+    let resolvedData: TData | null = null;
+    if (response) {
+      resolvedData = resolve?.(data, previousData) ?? data;
+    }
+
     return children(resolvedData, states, actions, meta);
   }
 }

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
-import Get, { GetDataError, GetMethod, GetProps } from "./Get";
+import Get, { GetMethod, GetProps } from "./Get";
+import { GetDataError } from "./types";
 
 export { default as RestfulProvider, RestfulReactProviderProps } from "./Context";
 export { default as Poll, PollProps } from "./Poll";

--- a/src/types.ts
+++ b/src/types.ts
@@ -4,9 +4,16 @@
  * A function that resolves returned data from
  * a fetch call.
  */
-export type ResolveFunction<T> = ((data: any) => T) | ((data: any) => Promise<T>);
+export type ResolveFunction<TData> = (data: any) => TData | Promise<TData>;
+
+/**
+ * A function that resolves returned data from
+ * a fetch call and the previous resolved data
+ */
+export type PollResolveFunction<TData> = (data: any, prevData: TData | null) => TData;
 
 export interface GetDataError<TError> {
   message: string;
-  data: TError | string;
+  data?: TError;
+  status?: number;
 }

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -10,6 +10,7 @@ import { GetState } from "./Get";
 import { processResponse } from "./util/processResponse";
 import { useDeepCompareEffect } from "./util/useDeepCompareEffect";
 import { useAbort } from "./useAbort";
+import { ResolveFunction } from "./types";
 
 export type Omit<T, K extends keyof T> = Pick<T, Exclude<keyof T, K>>;
 
@@ -41,7 +42,7 @@ export interface UseGetProps<TData, TError, TQueryParams, TPathParams> {
    * A function to resolve data return from the backend, most typically
    * used when the backend response needs to be adapted in some way.
    */
-  resolve?: (data: any) => TData;
+  resolve?: ResolveFunction<TData>;
   /**
    * Developer mode
    * Override the state with some mocks values and avoid to fetch
@@ -93,14 +94,7 @@ async function _fetchData<TData, TError, TQueryParams, TPathParams>(
   abort: () => void,
   getAbortSignal: () => AbortSignal | undefined,
 ) {
-  const {
-    base = context.base,
-    path,
-    resolve = (d: any) => d as TData,
-    queryParams = {},
-    requestOptions,
-    pathParams = {},
-  } = props;
+  const { base = context.base, path, resolve, queryParams = {}, requestOptions, pathParams = {} } = props;
 
   if (state.loading) {
     // Abort previous requests
@@ -150,7 +144,7 @@ async function _fetchData<TData, TError, TQueryParams, TPathParams>(
       return;
     }
 
-    setState({ ...state, error: null, loading: false, data: resolve(data) });
+    setState({ ...state, error: null, loading: false, data: resolve?.(data) ?? data });
   } catch (e) {
     // avoid state updates when component has been unmounted
     // and when fetch/processResponse threw an error

--- a/src/useMutate.test.tsx
+++ b/src/useMutate.test.tsx
@@ -43,13 +43,13 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useMutate("DELETE", ""), { wrapper });
-      const res = await result.current.mutate("plop");
+      await result.current.mutate("plop");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should call the correct url with a specific id (base in options)", async () => {
@@ -63,13 +63,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", "", { base: "https://my-awesome-api.fake" }), {
         wrapper,
       });
-      const res = await result.current.mutate("plop");
+      await result.current.mutate("plop");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should call the correct url with a specific id (base and path in options)", async () => {
@@ -83,13 +83,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", "user", { base: "https://my-awesome-api.fake" }), {
         wrapper,
       });
-      const res = await result.current.mutate("plop");
+      await result.current.mutate("plop");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should call the correct url without id", async () => {
@@ -103,13 +103,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", ""), {
         wrapper,
       });
-      const res = await result.current.mutate("");
+      await result.current.mutate("");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should deal with query parameters", async () => {
@@ -126,13 +126,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", "", { queryParams: { myParam: true } }), {
         wrapper,
       });
-      const res = await result.current.mutate("");
+      await result.current.mutate("");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
   });
 
@@ -153,13 +153,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", ""), {
         wrapper,
       });
-      const res = await result.current.mutate("");
+      await result.current.mutate("");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { vegan: false },
       });
-      expect(res).toEqual({ vegan: false });
     });
 
     it("should override the provider's query parameters if own specified", async () => {
@@ -178,13 +178,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", "", { queryParams: { cheese: "yucky" } }), {
         wrapper,
       });
-      const res = await result.current.mutate("");
+      await result.current.mutate("");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { vegan: true },
       });
-      expect(res).toEqual({ vegan: true });
     });
 
     it("should merge with the provider's query parameters if both specified", async () => {
@@ -204,13 +204,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", "", { queryParams: { cheese: "yucky" } }), {
         wrapper,
       });
-      const res = await result.current.mutate("");
+      await result.current.mutate("");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { vegan: "confused" },
       });
-      expect(res).toEqual({ vegan: "confused" });
     });
 
     it("should override query parameters if specified in mutate method", async () => {
@@ -230,13 +230,13 @@ describe("useMutate", () => {
       const { result } = renderHook(() => useMutate("DELETE", "", { queryParams: { cheese: "chucky" } }), {
         wrapper,
       });
-      const res = await result.current.mutate("", { queryParams: { cheese: "yucky" } });
+      await result.current.mutate("", { queryParams: { cheese: "yucky" } });
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { vegan: "confused" },
       });
-      expect(res).toEqual({ vegan: "confused" });
     });
 
     it("should parse the querystring regarding the options", async () => {
@@ -260,13 +260,15 @@ describe("useMutate", () => {
           wrapper,
         },
       );
-      const res = await result.current.mutate("");
+      await result.current.mutate("");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: {
+          vegan: true,
+        },
       });
-      expect(res).toEqual({ vegan: true });
     });
   });
 
@@ -288,13 +290,13 @@ describe("useMutate", () => {
           wrapper,
         },
       );
-      const res = await result.current.mutate({});
+      await result.current.mutate({});
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should override path parameters if specified in mutate method", async () => {
@@ -314,13 +316,13 @@ describe("useMutate", () => {
           wrapper,
         },
       );
-      const res = await result.current.mutate({}, { pathParams: { id: "one" } });
+      await result.current.mutate({}, { pathParams: { id: "one" } });
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
   });
 
@@ -353,13 +355,13 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useMutate<{ id: number }, unknown, {}, {}>("POST", ""), { wrapper });
-      const res = await result.current.mutate({});
+      await result.current.mutate({});
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should send the correct body", async () => {
@@ -371,13 +373,13 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useMutate("POST", ""), { wrapper });
-      const res = await result.current.mutate({ foo: "bar" });
+      await result.current.mutate({ foo: "bar" });
 
       expect(result.current).toMatchObject({
         error: null,
+        data: { id: 1 },
         loading: false,
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should return the data and the message on error", async () => {
@@ -389,24 +391,17 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useMutate("POST", ""), { wrapper });
-      try {
-        await result.current.mutate({ foo: "bar" });
-        expect("this statement").toBe("not executed");
-      } catch (e) {
-        expect(result.current).toMatchObject({
-          error: {
-            data: { error: "I can't, I'm just a chicken!" },
-            message: "Failed to fetch: 500 Internal Server Error",
-            status: 500,
-          },
-          loading: false,
-        });
-        expect(e).toEqual({
-          data: { error: "I can't, I'm just a chicken!" },
-          message: "Failed to fetch: 500 Internal Server Error",
-          status: 500,
-        });
-      }
+      await result.current.mutate({ foo: "bar" });
+
+      expect(result.current.error).toStrictEqual({
+        data: { error: "I can't, I'm just a chicken!" },
+        message: "Failed to fetch: 500 Internal Server Error",
+        status: 500,
+      });
+      expect(result.current).toMatchObject({
+        loading: false,
+        data: null,
+      });
     });
 
     it("should call onMutation", async () => {
@@ -434,26 +429,17 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useMutate("POST", ""), { wrapper });
-      try {
-        await result.current.mutate({ foo: "bar" });
-        expect("this statement").toBe("not executed");
-      } catch (e) {
-        expect(result.current).toMatchObject({
-          error: {
-            data:
-              "invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
-            message: "Failed to fetch: 200 OK",
-            status: 200,
-          },
-          loading: false,
-        });
-        expect(e).toEqual({
-          data:
-            "invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
-          message: "Failed to fetch: 200 OK",
-          status: 200,
-        });
-      }
+      await result.current.mutate({ foo: "bar" });
+      expect(result.current.error).toStrictEqual({
+        data:
+          "invalid json response body at https://my-awesome-api.fake/ reason: Unexpected token < in JSON at position 0",
+        message: "Failed to fetch: 200 OK",
+        status: 200,
+      });
+      expect(result.current).toMatchObject({
+        loading: false,
+        data: null,
+      });
     });
 
     it("should call the provider onError", async () => {
@@ -500,9 +486,7 @@ describe("useMutate", () => {
         wrapper,
       });
 
-      await result.current.mutate({}).catch(() => {
-        /* noop */
-      });
+      await result.current.mutate({});
 
       expect(onError).toBeCalledWith(
         {
@@ -514,8 +498,8 @@ describe("useMutate", () => {
         expect.any(Object), // response
       );
 
-      const data = await onError.mock.calls[0][1](); // call retry
-      expect(data).toEqual({ message: "You shall pass :)" });
+      await onError.mock.calls[0][1](); // call retry
+      expect(result.current.data).toEqual({ message: "You shall pass :)" });
     });
 
     it("should not call the provider onError if localErrorOnly is true", async () => {
@@ -551,13 +535,13 @@ describe("useMutate", () => {
           }),
         { wrapper },
       );
-      const res = await result.current.mutate({});
+      await result.current.mutate({});
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 2 },
       });
-      expect(res).toEqual({ id: 2 });
     });
 
     it("should forward the resolve error", async () => {
@@ -665,13 +649,13 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useDeleteMyCustomEndpoint({ queryParams: { force: true } }), { wrapper });
-      const res = await result.current.mutate("plop");
+      await result.current.mutate("plop");
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: { id: 1 },
       });
-      expect(res).toEqual({ id: 1 });
     });
 
     it("should call the correct endpoint (POST)", async () => {
@@ -712,13 +696,15 @@ describe("useMutate", () => {
         <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
       );
       const { result } = renderHook(() => useDeleteMyCustomEndpoint({ queryParams: { force: true } }), { wrapper });
-      const res = await result.current.mutate({ id: 1 });
+      await result.current.mutate({ id: 1 });
 
       expect(result.current).toMatchObject({
         error: null,
         loading: false,
+        data: {
+          id: 1,
+        },
       });
-      expect(res).toEqual({ id: 1 });
     });
   });
 });

--- a/src/util/resolveData.ts
+++ b/src/util/resolveData.ts
@@ -10,19 +10,12 @@ export const resolveData = async <TData, TError>({
   let resolvedData: TData | null = null;
   let resolveError: GetDataError<TError> | null = null;
   try {
-    if (resolve) {
-      const resolvedDataOrPromise: TData | Promise<TData> = resolve(data);
-      resolvedData = (resolvedDataOrPromise as { then?: any }).then
-        ? ((await resolvedDataOrPromise) as TData)
-        : (resolvedDataOrPromise as TData);
-    } else {
-      resolvedData = data;
-    }
+    resolvedData = await (resolve?.(data) ?? data);
   } catch (err) {
     resolvedData = null;
     resolveError = {
       message: "RESOLVE_ERROR",
-      data: JSON.stringify(err),
+      data: (JSON.stringify(err) as unknown) as TError,
     };
   }
   return {


### PR DESCRIPTION
Closes #235 

We make two changes to mutation:
    1. Don't throw on non-OK HTTP responses
    2. Don't return data, but set state

This is in order to mimic other data fetching options. For more
motivation on this, see this GitHub issue: https://github.com/contiamo/restful-react/issues/235

We also do some minor cleanup of types to avoid repetition and slighly
inconsistent types.

**Up for discussion:**
Shortly after finishing this code I got a new idea: what if errors that happen on **our** end are thrown, whereas errors that happen on the **server** end are paased in the `error` object returned from `useMutate`? This would mean: 

1. If the server returns with 4xx or 5xx we do the same thing as is happening in this code
2. If we fail to fetch (all the `catch`es after `fetch(...)`) we throw the error. From my understanding, the only times `fetch` throws is when it encounters serios networking errors, such as having no internet connection, running into CORS issues, or SSL issues. These events are truly exceptional, and since `fetch` throws them I think it's OK that we also throw them.
3. If the `resolve` function throws an error, we forward the error. 

This accomplishes a few things: 

1. We forward any errors caused by `fetch` or the users own code
2. OpenAPI (Swagger) works really nice with this approach: all `error`s from `useMutate`, `useGet`, etc get their proper typings from the OpenAPI spec files. Typing the errors from `resolve` or `fetch` on the other hand is much more difficult, since these events are not part of what OpenAPI describes. 


---

Let me know if it is hard to understand what I'm describing here, and I can see I can code up a prototype. This proposal would be a bit more work than what's here right now, and I'd like to get your guys' thoughts before spending a lot of time on it. 