### PR TITLE
Fix README: rename mocks prop to mock

### DIFF
--- a/README.md
+++ b/README.md
@@ -434,7 +434,7 @@ Each mutation returns a promise that can then be used to update local component 
 
 No backend support yet for your amazing feature? Need to isolate an edge case? You can easily provide a mock to `useMutate` and `useGet` to bypass the classic flow.
 
-/!\ If `mocks` option is provided, no requests will be send to the server. /!\
+/!\ If `mock` option is provided, no requests will be send to the server. /!\
 
 ```jsx
 import React from "react";
@@ -448,7 +448,7 @@ const { mutate: del, loading } = useMutate({
   path: `/posts/`,
   base,
   // This will avoid any server call in favor of mock response
-  mocks: {
+  mock: {
     mutate: id => console.log(`The item ${id} was deleted`),
   },
 });
@@ -458,7 +458,7 @@ const { data: posts } = useGet({
   path: "/posts",
   base,
   // This will avoid any server call in favor of mock response
-  mocks: {
+  mock: {
     loading: true,
   },
 });
@@ -468,7 +468,7 @@ const { data: posts } = useGet({
   path: "/posts",
   base,
   // This will avoid any server call in favor of mock response
-  mocks: {
+  mock: {
     error: "oh no!",
   },
 });

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "restful-react",
-  "version": "14.5.0",
+  "version": "14.5.1",
   "description": "A consistent, declarative way of interacting with RESTful backends, featuring code-generation from Swagger and OpenAPI specs",
   "keywords": [
     "rest",

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -744,7 +744,7 @@ Path    : ${i.path}`),
  * Get the url encoding function to be aliased at the module scope.
  * This function is used to encode the path parameters.
  *
- * @param mode Either "uricomponent" or "rfc". "rfc" mode also encodes
+ * @param mode Either "uricomponent" or "rfc3986". "rfc3986" mode also encodes
  *             symbols from the `!'()*` range, while "uricomponent" leaves those as is.
  */
 const getEncodingFunction = (mode: "uriComponent" | "rfc3986") => {


### PR DESCRIPTION
# Why

Nothing special, it just fixes typo in readme based on this PR https://github.com/contiamo/restful-react/pull/274