### PR TITLE
Handle body object for DELETE request

### DIFF
--- a/src/Mutate.test.tsx
+++ b/src/Mutate.test.tsx
@@ -109,6 +109,70 @@ describe("Mutate", () => {
       expect(children.mock.calls[2][1].loading).toEqual(false);
     });
 
+    it("should send the correct body", async () => {
+      nock("https://my-awesome-api.fake")
+        .delete("/", { foo: "bar" })
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Mutate verb="DELETE" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // delete action
+      children.mock.calls[0][0]({ foo: "bar" });
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after delete state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+
+    it("should send the empty body object", async () => {
+      nock("https://my-awesome-api.fake")
+        .delete("/", {})
+        .reply(200, { id: 1 });
+
+      const children = jest.fn();
+      children.mockReturnValue(<div />);
+
+      // setup - first render
+      render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <Mutate verb="DELETE" path="">
+            {children}
+          </Mutate>
+        </RestfulProvider>,
+      );
+
+      await wait(() => expect(children.mock.calls.length).toBe(1));
+      expect(children.mock.calls[0][1].loading).toEqual(false);
+      expect(children.mock.calls[0][0]).toBeDefined();
+
+      // delete action
+      children.mock.calls[0][0]({});
+      await wait(() => expect(children.mock.calls.length).toBe(3));
+
+      // transition state
+      expect(children.mock.calls[1][1].loading).toEqual(true);
+
+      // after delete state
+      expect(children.mock.calls[2][1].loading).toEqual(false);
+    });
+
     it("should call the correct url without id", async () => {
       nock("https://my-awesome-api.fake")
         .delete("/")

--- a/src/useMutate.test.tsx
+++ b/src/useMutate.test.tsx
@@ -92,6 +92,42 @@ describe("useMutate", () => {
       expect(res).toEqual({ id: 1 });
     });
 
+    it("should send the correct body", async () => {
+      nock("https://my-awesome-api.fake")
+        .delete("/", { foo: "bar" })
+        .reply(200, { id: 1 });
+
+      const wrapper: React.FC = ({ children }) => (
+        <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
+      );
+      const { result } = renderHook(() => useMutate("DELETE", ""), { wrapper });
+      const res = await result.current.mutate({ foo: "bar" });
+
+      expect(result.current).toMatchObject({
+        error: null,
+        loading: false,
+      });
+      expect(res).toEqual({ id: 1 });
+    });
+
+    it("should send the empty body object", async () => {
+      nock("https://my-awesome-api.fake")
+        .delete("/", {})
+        .reply(200, { id: 1 });
+
+      const wrapper: React.FC = ({ children }) => (
+        <RestfulProvider base="https://my-awesome-api.fake">{children}</RestfulProvider>
+      );
+      const { result } = renderHook(() => useMutate("DELETE", ""), { wrapper });
+      const res = await result.current.mutate({});
+
+      expect(result.current).toMatchObject({
+        error: null,
+        loading: false,
+      });
+      expect(res).toEqual({ id: 1 });
+    });
+
     it("should call the correct url without id", async () => {
       nock("https://my-awesome-api.fake")
         .delete("/")


### PR DESCRIPTION
# Why

Resolves #288 

This is fully backward compatible for body of type string/number. So, this PR adds supports for body as `FormData` or `Object` which is useful for some cases.

Nice, that it's already like this in Mutate component. Only the hook has missed this point. 

p.s somehow we need to avoid duplicating code/tests in the component and hook (If you have the same feeling, let me know, I will open a new issue to discuss in more details). Probably, I don't fully understand the idea of having two sources of truth (Component and Hook) instead of one (Hook).

So, my idea is to use hook in the component directly. So, all logic will be in one place (Hook).
Just an example:
```jsx
function Mutate({ children, ...mutateProps }) {
  const { mutate, loading, error, absolutePath } = useMutate(mutateProps);

  return children(mutate, { loading, error }, { absolutePath });
}

export default Mutate;
```

thoughts? 🤔 
