### PR TITLE
Add params in function requestOptions

### DIFF
--- a/README.md
+++ b/README.md
@@ -168,7 +168,7 @@ export interface RestfulReactProviderProps<T = any> {
   /**
    * Options passed to the fetch request.
    */
-  requestOptions?: (() => Partial<RequestInit>) | Partial<RequestInit>;
+  requestOptions?: ((url: string, method: string, requestBody?: string) => Partial<RequestInit>) | Partial<RequestInit>;
   /**
    * Trigger on each error.
    * For `Get` and `Mutation` calls, you can also call `retry` to retry the exact same request.

--- a/README.md
+++ b/README.md
@@ -199,7 +199,7 @@ export interface RestfulReactProviderProps<T = any> {
 <RestfulProvider
   base="String!"
   resolve={data => data}
-  requestOptions={authToken => ({ headers: { Authorization: authToken } })}
+  requestOptions={(url, method, requestBody) => ({ headers: { Authorization: authToken } })}
 />;
 ```
 

--- a/src/Context.tsx
+++ b/src/Context.tsx
@@ -19,7 +19,13 @@ export interface RestfulReactProviderProps<TData = any> {
   /**
    * Options passed to the fetch request.
    */
-  requestOptions?: (() => Partial<RequestInit> | Promise<Partial<RequestInit>>) | Partial<RequestInit>;
+  requestOptions?:
+    | (<TRequestBody>(
+        url: string,
+        method: string,
+        requestBody?: TRequestBody,
+      ) => Partial<RequestInit> | Promise<Partial<RequestInit>>)
+    | Partial<RequestInit>;
   /**
    * Trigger on each error.
    * For `Get` and `Mutation` calls, you can also call `retry` to retry the exact same request.

--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -212,13 +212,14 @@ class ContextlessGet<TData, TError, TQueryParams, TPathParams = unknown> extends
   }
 
   public getRequestOptions = async (
+    url: string,
     extraOptions?: Partial<RequestInit>,
     extraHeaders?: boolean | { [key: string]: string },
   ) => {
     const { requestOptions } = this.props;
 
     if (typeof requestOptions === "function") {
-      const options = (await requestOptions()) || {};
+      const options = (await requestOptions(url, "GET")) || {};
       return {
         ...extraOptions,
         ...options,
@@ -263,7 +264,7 @@ class ContextlessGet<TData, TError, TQueryParams, TPathParams = unknown> extends
       return url;
     };
 
-    const request = new Request(makeRequestPath(), await this.getRequestOptions(thisRequestOptions));
+    const request = new Request(makeRequestPath(), await this.getRequestOptions(makeRequestPath(), thisRequestOptions));
     if (onRequest) onRequest(request);
     try {
       const response = await fetch(request, { signal: this.signal });

--- a/src/Mutate.tsx
+++ b/src/Mutate.tsx
@@ -182,12 +182,14 @@ class ContextlessMutate<TData, TError, TQueryParams, TRequestBody, TPathParams> 
     const request = new Request(makeRequestPath(), {
       method: verb,
       body: typeof body === "object" ? JSON.stringify(body) : body,
-      ...(typeof providerRequestOptions === "function" ? providerRequestOptions() : providerRequestOptions),
+      ...(typeof providerRequestOptions === "function"
+        ? await providerRequestOptions<TRequestBody>(makeRequestPath(), verb, body)
+        : providerRequestOptions),
       ...mutateRequestOptions,
       headers: {
         "content-type": typeof body === "object" ? "application/json" : "text/plain",
         ...(typeof providerRequestOptions === "function"
-          ? (await providerRequestOptions()).headers
+          ? (await providerRequestOptions<TRequestBody>(makeRequestPath(), verb, body)).headers
           : (providerRequestOptions || {}).headers),
         ...(mutateRequestOptions ? mutateRequestOptions.headers : {}),
       },

--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -574,7 +574,9 @@ describe("useGet hook", () => {
     });
 
     it("should merge headers with providers", async () => {
-      nock("https://my-awesome-api.fake", { reqheaders: { foo: "bar", bar: "foo" } })
+      nock("https://my-awesome-api.fake", {
+        reqheaders: { foo: "bar", bar: "foo", visitUrl: "https://my-awesome-api.fake/", visitMethod: "GET" },
+      })
         .get("/")
         .reply(200, { oh: "my god 😍" });
 
@@ -585,7 +587,12 @@ describe("useGet hook", () => {
       };
 
       const { getByTestId } = render(
-        <RestfulProvider base="https://my-awesome-api.fake" requestOptions={() => ({ headers: { bar: "foo" } })}>
+        <RestfulProvider
+          base="https://my-awesome-api.fake"
+          requestOptions={(url, method) => {
+            return { headers: { bar: "foo", visitUrl: url, visitMethod: method } };
+          }}
+        >
           <MyAwesomeComponent />
         </RestfulProvider>,
       );

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -114,22 +114,24 @@ async function _fetchData<TData, TError, TQueryParams, TPathParams>(
 
   const pathStr = typeof path === "function" ? path(pathParams as TPathParams) : path;
 
-  const propsRequestOptions = (typeof requestOptions === "function" ? await requestOptions() : requestOptions) || {};
+  const url = resolvePath(
+    base,
+    pathStr,
+    { ...context.queryParams, ...queryParams },
+    { ...context.queryParamStringifyOptions, ...queryParamStringifyOptions },
+  );
+
+  const propsRequestOptions =
+    (typeof requestOptions === "function" ? await requestOptions(url, "GET") : requestOptions) || {};
 
   const contextRequestOptions =
-    (typeof context.requestOptions === "function" ? await context.requestOptions() : context.requestOptions) || {};
+    (typeof context.requestOptions === "function"
+      ? await context.requestOptions(url, "GET")
+      : context.requestOptions) || {};
 
   const signal = getAbortSignal();
 
-  const request = new Request(
-    resolvePath(
-      base,
-      pathStr,
-      { ...context.queryParams, ...queryParams },
-      { ...context.queryParamStringifyOptions, ...queryParamStringifyOptions },
-    ),
-    merge({}, contextRequestOptions, propsRequestOptions, { signal }),
-  );
+  const request = new Request(url, merge({}, contextRequestOptions, propsRequestOptions, { signal }));
   if (context.onRequest) context.onRequest(request);
 
   try {


### PR DESCRIPTION
# Why

In some usecases, we would like add new values into request header which are depend on the request content.

For example, we tried to implement authentication method [oauth-dpop](https://tools.ietf.org/html/draft-ietf-oauth-dpop-01), but we found we don't have enough information in function requestOptions (request's url, method)

The original function:
```ts
() => Partial<RequestInit>
```

I modified this function like this:
```ts
(url: string, method: string, requestBody?: string) => Partial<RequestInit>)
```

So that we can achieve our purpose.
```ts
<RestfulProvider
  base="String!"
  resolve={data => data}
  requestOptions={async (url, method) => {
    // generate JWT with request's url and method.
    const dpopProofJWT = await DPoP(keypair, 'ES256', url, method);
    return { headers: { DPoP: dpopProofJWT } }
  }}
/>;
```

Please let me know if you have any concern, thank you!
