### PR TITLE
#298 Version releases without git tags

### DIFF
--- a/.github/workflows/npm-publish.yaml
+++ b/.github/workflows/npm-publish.yaml
@@ -2,8 +2,8 @@ name: Npm publish
 
 on:
   push:
-    branches:
-      - master
+    tags:
+      - '*'
     paths:
       - package.json
 


### PR DESCRIPTION
Only git tags leads to an npm publish.

# Why
https://github.com/contiamo/restful-react/issues/298