### PR TITLE
Clear the `data` after an error

### DIFF
--- a/src/Get.tsx
+++ b/src/Get.tsx
@@ -285,6 +285,7 @@ class ContextlessGet<TData, TError, TQueryParams, TPathParams = unknown> extends
         this.setState({
           loading: false,
           error,
+          data: null,
         });
 
         if (!this.props.localErrorOnly && onError) {
@@ -307,6 +308,7 @@ class ContextlessGet<TData, TError, TQueryParams, TPathParams = unknown> extends
 
       this.setState({
         loading: false,
+        data: null,
         error: {
           message: `Failed to fetch: ${e.message}`,
           data: e,

--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -137,7 +137,7 @@ async function _fetchData<TData, TError, TQueryParams, TPathParams>(
         status: response.status,
       };
 
-      setState({ ...state, loading: false, error });
+      setState({ ...state, loading: false, data: null, error });
 
       if (!props.localErrorOnly && context.onError) {
         context.onError(error, () => _fetchData(props, state, setState, context, abort, getAbortSignal), response);
@@ -160,6 +160,7 @@ async function _fetchData<TData, TError, TQueryParams, TPathParams>(
 
     setState({
       ...state,
+      data: null,
       loading: false,
       error,
     });


### PR DESCRIPTION
# Why

Having some stale data after error is really confusing and causing some issues.
We also don't have any good use cases in mind where having the previous data can be useful, so let's simplify the library behaviour.
