### PR TITLE
Add support for returning original response

### DIFF
--- a/src/useGet.test.tsx
+++ b/src/useGet.test.tsx
@@ -645,6 +645,63 @@ describe("useGet hook", () => {
     });
   });
 
+  describe("originalResponse", () => {
+    it("should return original response when flag is enabled", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { oh: "my god 😍" });
+
+      const MyAwesomeComponent = () => {
+        const { loading, response } = useGet({
+          path: "/",
+          originalResponse: true,
+        });
+
+        return loading ? (
+          <div data-testid="loading">Loading…</div>
+        ) : (
+          <div data-testid="response">{response ? JSON.stringify(response) : null}</div>
+        );
+      };
+
+      const { getByTestId } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      await waitForElement(() => getByTestId("response"));
+      expect(getByTestId("response")).not.toBeEmpty();
+    });
+
+    it("should not return original response when flag is disabled", async () => {
+      nock("https://my-awesome-api.fake")
+        .get("/")
+        .reply(200, { oh: "my god 😍" });
+
+      const MyAwesomeComponent = () => {
+        const { loading, response } = useGet({
+          path: "/",
+        });
+
+        return loading ? (
+          <div data-testid="loading">Loading…</div>
+        ) : (
+          <div data-testid="response">{response ? JSON.stringify(response) : null}</div>
+        );
+      };
+
+      const { getByTestId } = render(
+        <RestfulProvider base="https://my-awesome-api.fake">
+          <MyAwesomeComponent />
+        </RestfulProvider>,
+      );
+
+      await waitForElement(() => getByTestId("response"));
+      expect(getByTestId("response")).toBeEmpty();
+    });
+  });
+
   describe("actions", () => {
     it("should refetch", async () => {
       nock("https://my-awesome-api.fake")


### PR DESCRIPTION
# Why

This will allow the user to pass the flag `orginalResponse` to `useGet` to enable returning the original response object.
This solves the requirement where a user needs to access the response headers per request. 
Putting this behind a new flag keeps the API backward-compatible and opt-in for performance reasons (since the response object can be pretty large).

Related issues: 
- https://github.com/contiamo/restful-react/issues/297
- https://github.com/contiamo/restful-react/issues/173

This is different from `onResponse` added in https://github.com/contiamo/restful-react/pull/254 as this allows per-request handling of response headers instead of global handling.

I have already added tests to showcase how this works. I can add this to the Readme also once this gets reviewed.