### PR TITLE
Stabilize use mutate even more

### DIFF
--- a/src/useMutate.test.tsx
+++ b/src/useMutate.test.tsx
@@ -490,8 +490,8 @@ describe("useMutate", () => {
       await result.current.mutate({});
       const mutate2 = result.current.mutate;
 
-      expect(mutate0).toEqual(mutate1);
-      expect(mutate0).toEqual(mutate2);
+      expect(mutate0).toBe(mutate1);
+      expect(mutate0).toBe(mutate2);
     });
   });
 

--- a/src/util/useDeepCompareEffect.ts
+++ b/src/util/useDeepCompareEffect.ts
@@ -1,5 +1,5 @@
 import isEqualWith from "lodash/isEqualWith";
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 
 /**
  * Custom version of isEqual to handle function comparison
@@ -36,4 +36,8 @@ function useDeepCompareMemoize(value: Readonly<any>) {
  */
 export function useDeepCompareEffect<T>(effect: React.EffectCallback, deps: T) {
   useEffect(effect, useDeepCompareMemoize(deps));
+}
+
+export function useDeepCompareCallback<T extends (...args: any[]) => any>(callback: T, deps: readonly any[]) {
+  return useCallback(callback, useDeepCompareMemoize(deps));
 }


### PR DESCRIPTION
Revisiting #335 in light of the issue noted in #337

Stabilize the useMutate function even more by using a deep
compare effect. This better handles cases in which the argument to
`useMutate` is an inline object, which is the typical use case.