### PR TITLE
stabilize the identity of useGet and its refetch method

### DIFF
--- a/src/util/useDeepCompareEffect.ts
+++ b/src/util/useDeepCompareEffect.ts
@@ -1,5 +1,5 @@
 import isEqualWith from "lodash/isEqualWith";
-import React, { useEffect, useRef } from "react";
+import React, { useCallback, useEffect, useRef } from "react";
 
 /**
  * Custom version of isEqual to handle function comparison
@@ -36,4 +36,8 @@ function useDeepCompareMemoize(value: Readonly<any>) {
  */
 export function useDeepCompareEffect<T>(effect: React.EffectCallback, deps: T) {
   useEffect(effect, useDeepCompareMemoize(deps));
+}
+
+export function useDeepCompareCallback<T extends (...args: any[]) => any>(callback: T, deps: readonly any[]) {
+  return useCallback(callback, useDeepCompareMemoize(deps));
 }


### PR DESCRIPTION
Stabilizing the identity of the `fetchData` function presents some
challenges. The biggest is that `fetchData` needs to have access to
`state` and `setState`, but it needs to have the most up-to-date version
of them in order to work. There are two ways to have done this: the
first is to move the definition of `fetchData` into the function body of
`useGet` itself and make it a closure over the `state` and `setState`
variables - that is the approach taken here. Alternatively, we could
define `fetchData` as a function which takes `state` and `setState` as
parameters, but is closed over a particular combination of props and
context values - this option wasn't explored.

The end result is that the identity of the `refetch` function is stable
given a certain set of props and context, and it is stable over a deep
comparison thereof - so both of the following work fine:
```typescript
const queryParams = { page: 1 };
function MyComponent = () => {
  const { refetch } = useGet({ queryParams, lazy: true })`
  ...
};
```

```typescript
function MyComponent = () => {
  const { refetch } = useGet({ { page: 1 }, lazy: true })`
  ...
};
```

This should resolve #186 fully (I hope!)

# Why
Solves #186

## NB

There are 3 tests which suffer from the same symptom: for a reason I haven't completely tracked down, there is an extra re-render dispatched by the hook with identical state: in both instances, it is when the re-render is called, there are 2 returns out of the hook with `loading: true`. I don't suppose this will cause any issues with any callers, but I was unable to totally root it out.

Note that this uses the same `useDeepCompareCallback` that is also present in #338 - the implementation in either case is identical and could be rebased out safely depending on merge order.