### PR TITLE
Add support for anyOf

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -107,7 +107,7 @@ export const getArray = (item: SchemaObject): string => {
     throw new Error("All arrays must have an `items` key defined");
   }
   let item_type = resolveValue(item.items);
-  if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
+  if (!isReference(item.items) && (item.items.oneOf || item.items.anyOf || item.items.allOf || item.items.enum)) {
     item_type = `(${item_type})`;
   }
   if (item.minItems && item.maxItems && item.minItems === item.maxItems) {
@@ -136,6 +136,10 @@ export const getObject = (item: SchemaObject): string => {
       return requireProperties(composedType, item.required);
     }
     return composedType;
+  }
+
+  if (item.anyOf) {
+    return item.anyOf.map(resolveValue).join(" | ");
   }
 
   if (item.oneOf) {
@@ -649,6 +653,7 @@ export const generateSchemasDefinition = (schemas: ComponentsObject["schemas"] =
         !isReference(schema) &&
         (!schema.type || schema.type === "object") &&
         !schema.allOf &&
+        !schema.anyOf &&
         !schema.oneOf &&
         !isReference(schema) &&
         !schema.nullable

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -185,6 +185,25 @@ describe("scripts/import-open-api", () => {
       };
       expect(getArray(item)).toEqual("(Foo & Bar & Baz)[]");
     });
+    it("should return an array of anyOf", () => {
+      const item = {
+        items: {
+          anyOf: [
+            {
+              $ref: "#/components/schemas/foo",
+            },
+            {
+              $ref: "#/components/schemas/bar",
+            },
+            {
+              $ref: "#/components/schemas/baz",
+            },
+          ],
+        },
+        type: "array",
+      };
+      expect(getArray(item)).toEqual("(Foo | Bar | Baz)[]");
+    });
   });
 
   describe("getObject", () => {
@@ -347,6 +366,27 @@ describe("scripts/import-open-api", () => {
       };
       expect(getObject(item)).toMatchInlineSnapshot(`
                                                                 "Foo & {
+                                                                  name: string;
+                                                                }"
+                                                `);
+    });
+
+    it("should deal with anyOf", () => {
+      const item = {
+        type: "object",
+        anyOf: [
+          { $ref: "#/components/schemas/foo" },
+          {
+            type: "object",
+            required: ["name"],
+            properties: {
+              name: { type: "string" },
+            },
+          },
+        ],
+      };
+      expect(getObject(item)).toMatchInlineSnapshot(`
+                                                                "Foo | {
                                                                   name: string;
                                                                 }"
                                                 `);
@@ -781,7 +821,7 @@ describe("scripts/import-open-api", () => {
                                                       `);
     });
 
-    it("should declare a a type for union object", () => {
+    it("should declare a type for union object", () => {
       const responses: ComponentsObject["responses"] = {
         JobRun: {
           description: "Job is starting",


### PR DESCRIPTION
OpenAPI schemas with `anyOf[A,B]` should generate a type `A | B` not `{}`.

https://swagger.io/docs/specification/data-models/oneof-anyof-allof-not/
