### PR TITLE
Add support for tuples

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -105,13 +105,11 @@ export const getRef = ($ref: ReferenceObject["$ref"]) => {
 export const getArray = (item: SchemaObject): string => {
   if (!item.items) {
     throw new Error("All arrays must have an `items` key defined");
-  } else {
-    if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
-      return `(${resolveValue(item.items)})[]`;
-    } else {
-      return `${resolveValue(item.items)}[]`;
-    }
   }
+  if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
+    return `(${resolveValue(item.items)})[]`;
+  }
+  return `${resolveValue(item.items)}[]`;
 };
 
 /**

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -106,10 +106,11 @@ export const getArray = (item: SchemaObject): string => {
   if (!item.items) {
     throw new Error("All arrays must have an `items` key defined");
   }
+  const item_type = resolveValue(item.items);
   if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
-    return `(${resolveValue(item.items)})[]`;
+    return `(${item_type})[]`;
   }
-  return `${resolveValue(item.items)}[]`;
+  return `${item_type}[]`;
 };
 
 /**

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -106,9 +106,9 @@ export const getArray = (item: SchemaObject): string => {
   if (!item.items) {
     throw new Error("All arrays must have an `items` key defined");
   }
-  const item_type = resolveValue(item.items);
+  let item_type = resolveValue(item.items);
   if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
-    return `(${item_type})[]`;
+    item_type = `(${item_type})`;
   }
   return `${item_type}[]`;
 };

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -103,14 +103,14 @@ export const getRef = ($ref: ReferenceObject["$ref"]) => {
  * @param item item with type === "array"
  */
 export const getArray = (item: SchemaObject): string => {
-  if (item.items) {
+  if (!item.items) {
+    throw new Error("All arrays must have an `items` key defined");
+  } else {
     if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
       return `(${resolveValue(item.items)})[]`;
     } else {
       return `${resolveValue(item.items)}[]`;
     }
-  } else {
-    throw new Error("All arrays must have an `items` key defined");
   }
 };
 

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -110,6 +110,9 @@ export const getArray = (item: SchemaObject): string => {
   if (!isReference(item.items) && (item.items.oneOf || item.items.allOf || item.items.enum)) {
     item_type = `(${item_type})`;
   }
+  if (item.minItems && item.maxItems && item.minItems === item.maxItems) {
+    return `[${new Array(item.minItems).fill(item_type).join(", ")}]`;
+  }
   return `${item_type}[]`;
 };
 

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -71,6 +71,7 @@ describe("scripts/import-open-api", () => {
       { item: { type: "array", items: { type: "string" } }, expected: "string[]" },
       { item: { type: "array", items: { type: "integer" } }, expected: "number[]" },
       { item: { type: "array", items: { type: "customType" } }, expected: "any[]" },
+      { item: { type: "array", items: { type: "number" }, minItems: 2, maxItems: 2 }, expected: "[number, number]" },
       { item: { type: "object", properties: { value: { type: "integer" } } }, expected: "{\n  value?: number;\n}" },
       { item: { type: "object" }, expected: "{[key: string]: any}" },
       { item: { type: "object", $ref: "#/components/schemas/Foo" }, expected: "Foo" },

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -72,6 +72,10 @@ describe("scripts/import-open-api", () => {
       { item: { type: "array", items: { type: "integer" } }, expected: "number[]" },
       { item: { type: "array", items: { type: "customType" } }, expected: "any[]" },
       { item: { type: "array", items: { type: "number" }, minItems: 2, maxItems: 2 }, expected: "[number, number]" },
+      {
+        item: { type: "array", items: { type: "string", enum: ["foor", "bar"] }, minItems: 2, maxItems: 2 },
+        expected: `[("foor" | "bar"), ("foor" | "bar")]`,
+      },
       { item: { type: "object", properties: { value: { type: "integer" } } }, expected: "{\n  value?: number;\n}" },
       { item: { type: "object" }, expected: "{[key: string]: any}" },
       { item: { type: "object", $ref: "#/components/schemas/Foo" }, expected: "Foo" },


### PR DESCRIPTION
# Why

Currently if you generate types based on the following definition, `age_range` is typed as `number[]`

```yaml
age_range:
  description: 'A range of passenger ages (start and end, inclusively)'
  type: array
  items:
    type: number
  minItems: 2
  maxItems: 2
```

As the array should only contain two items, it would be nice if it was typed as `[number, number]`

## Note

This will conflict with #362, but if you support the idea, I'll rebase afterwards