### PR TITLE
Keep last path parameter when skipping React

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -344,7 +344,9 @@ export const generateRestfulComponent = (
    *    </DeleteResource>
    */
 
-  const paramsInPath = getParamsInPath(route).filter(param => !(verb === "delete" && param === lastParamInTheRoute));
+  const paramsInPath = getParamsInPath(route).filter(
+    param => !(!skipReact && verb === "delete" && param === lastParamInTheRoute),
+  );
   const { query: queryParams = [], path: pathParams = [], header: headerParams = [] } = groupBy(
     [...parameters, ...(operation.parameters || [])].map<ParameterObject>(p => {
       if (isReference(p)) {

--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -309,9 +309,9 @@ export const generateRestfulComponent = (
 
   route = route.replace(/\{/g, "${"); // `/pet/{id}` => `/pet/${id}`
 
-  // Remove the last param of the route if we are in the DELETE case
+  // Remove the last param of the route if we are in the DELETE case and generating React components/hooks
   let lastParamInTheRoute: string | null = null;
-  if (verb === "delete") {
+  if (!skipReact && verb === "delete") {
     const lastParamInTheRouteRegExp = /\/\$\{(\w+)\}\/?$/;
     lastParamInTheRoute = (route.match(lastParamInTheRouteRegExp) || [])[1];
     route = route.replace(lastParamInTheRouteRegExp, ""); // `/pet/${id}` => `/pet`
@@ -344,9 +344,7 @@ export const generateRestfulComponent = (
    *    </DeleteResource>
    */
 
-  const paramsInPath = getParamsInPath(route).filter(
-    param => !(!skipReact && verb === "delete" && param === lastParamInTheRoute),
-  );
+  const paramsInPath = getParamsInPath(route).filter(param => !(verb === "delete" && param === lastParamInTheRoute));
   const { query: queryParams = [], path: pathParams = [], header: headerParams = [] } = groupBy(
     [...parameters, ...(operation.parameters || [])].map<ParameterObject>(p => {
       if (isReference(p)) {

--- a/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
+++ b/src/scripts/tests/__snapshots__/import-open-api.test.ts.snap
@@ -301,6 +301,13 @@ export interface FindPetByIdPathParams {
 }
 
 
+export interface DeletePetPathParams {
+  /**
+   * ID of pet to delete
+   */
+  id: number
+}
+
 
 export interface UpdatePetPathParams {
   /**


### PR DESCRIPTION
Resolves #366 (see issue for motivation).

Adds all path parameters to generated interfaces for DELETE requests when `--skipReact` is set.