### PR TITLE
support enum on type number

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -52,7 +52,7 @@ export const getScalar = (item: SchemaObject) => {
     case "long":
     case "float":
     case "double":
-      return "number" + nullable;
+      return (item.enum ? `${item.enum.join(` | `)}` : "number") + nullable;
 
     case "boolean":
       return "boolean" + nullable;

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -66,6 +66,7 @@ describe("scripts/import-open-api", () => {
       { item: { type: "int64" }, expected: "number" },
       { item: { type: "float" }, expected: "number" },
       { item: { type: "number" }, expected: "number" },
+      { item: { type: "number", enum: [1, 2] }, expected: `1 | 2` },
       { item: { type: "double" }, expected: "number" },
       { item: { type: "boolean" }, expected: "boolean" },
       { item: { type: "array", items: { type: "string" } }, expected: "string[]" },


### PR DESCRIPTION
# Why

Given the following spec

```yaml
description: A representation of a floor of a bus.
title: Floor
type: object
properties:
  level:
    description: The floor number.
    enum:
      - 1
      - 2
    type: number
```

I would like the type to be generated as 

```ts
interface Floor {
  level: 1 | 2;
}
```


Additional question: I don't use React but this is the best library I found to generate type from OpenAPI specs, is there a plan to split this library into type generation & react related stuff? 
