### PR TITLE
Fix: empty required should not generate invalid types.

### DIFF
--- a/src/scripts/import-open-api.ts
+++ b/src/scripts/import-open-api.ts
@@ -132,7 +132,7 @@ export const getObject = (item: SchemaObject): string => {
 
   if (item.allOf) {
     const composedType = item.allOf.map(resolveValue).join(" & ");
-    if (item.required) {
+    if (item.required && item.required.length) {
       return requireProperties(composedType, item.required);
     }
     return composedType;
@@ -144,7 +144,7 @@ export const getObject = (item: SchemaObject): string => {
 
   if (item.oneOf) {
     const unionType = item.oneOf.map(resolveValue).join(" | ");
-    if (item.required) {
+    if (item.required && item.required.length) {
       return requireProperties(unionType, item.required);
     }
     return unionType;

--- a/src/scripts/tests/import-open-api.test.ts
+++ b/src/scripts/tests/import-open-api.test.ts
@@ -401,6 +401,15 @@ describe("scripts/import-open-api", () => {
       expect(getObject(item)).toEqual(`Require<Foo & Bar, "a_bar_property" | "a_foo_property">`);
     });
 
+    it("should deal with allOf and an empty required at root level", () => {
+      const item = {
+        type: "object",
+        allOf: [{ $ref: "#/components/schemas/foo" }, { $ref: "#/components/schemas/bar" }],
+        required: [],
+      };
+      expect(getObject(item)).toEqual(`Foo & Bar`);
+    });
+
     it("should deal with oneOf and required at root level", () => {
       const item = {
         type: "object",
@@ -408,6 +417,15 @@ describe("scripts/import-open-api", () => {
         required: ["a_common_property"],
       };
       expect(getObject(item)).toEqual(`Require<Foo | Bar, "a_common_property">`);
+    });
+
+    it("should deal with oneOf and an empty required at root level", () => {
+      const item = {
+        type: "object",
+        oneOf: [{ $ref: "#/components/schemas/foo" }, { $ref: "#/components/schemas/bar" }],
+        required: [],
+      };
+      expect(getObject(item)).toEqual(`Foo | Bar`);
     });
 
     it("should deal with oneOf with null", () => {


### PR DESCRIPTION
# Why

https://github.com/contiamo/restful-react/pull/364 introduced an issue with empty `required` lists: invalid types are generated in that case, e.g. `Require<Foo & Bar, >`.
