### PR TITLE
Allow fetchData in useGet to return data (so refetch can return data)

### DIFF
--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -99,7 +99,7 @@ export interface UseGetReturn<TData, TError, TQueryParams = {}, TPathParams = un
   /**
    * Refetch
    */
-  refetch: (options?: RefetchOptions<TData, TError, TQueryParams, TPathParams>) => Promise<void>;
+  refetch: (options?: RefetchOptions<TData, TError, TQueryParams, TPathParams>) => Promise<TData | null>;
 }
 
 export function useGet<TData = any, TError = any, TQueryParams = { [key: string]: any }, TPathParams = unknown>(
@@ -211,6 +211,7 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
           data: resolvedData,
           response: originalResponse,
         }));
+        return resolvedData;
       } catch (e) {
         // avoid state updates when component has been unmounted
         // and when fetch/processResponse threw an error
@@ -233,6 +234,8 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
         if (!props.localErrorOnly && context.onError) {
           context.onError(error, () => _fetchData(props, context, abort, getAbortSignal));
         }
+
+        return;
       }
     },
     [


### PR DESCRIPTION
# Why

Attempts to solve #268 by following the non-suggested path: muddle the `useGet` API by allowing `refetch` to return the data it just fetched, rather than making the caller put their code in an ambient `useEffect`
<!-- Why did you make this PR? What problem does it solve? -->

```tsx
# Uncomfortable
const { data, refetch } = useGet("/mycollection")
useEffect(() => {
  if (data.results.length > 1) {
    alert("There are several");
  }
}, [data]);
return (
  <button onClick={async () => {
    await refetch();
  }} />
);
```

```tsx
# Much clearer and closer to the `mutate` API
const { data: originalData, refetch } = useGet("/mycollection")

return (
  <button onClick={async () => {
    if ((await refetch()).results.length > 1) {
      alert("Several");
    }
  }} />
)
```