### PR TITLE
Skip network call when calling refetch with mock

### DIFF
--- a/src/useGet.tsx
+++ b/src/useGet.tsx
@@ -284,10 +284,15 @@ export function useGet<TData = any, TError = any, TQueryParams = { [key: string]
   }, [fetchData, props.lazy, props.mock]);
 
   const refetch = useCallback(
-    (options: RefetchOptions<TData, TError, TQueryParams, TPathParams> = {}) =>
-      fetchData({ ...props, ...options }, context, abort, getAbortSignal),
+    (options: RefetchOptions<TData, TError, TQueryParams, TPathParams> = {}) => {
+      if (!props.mock) {
+        return fetchData({ ...props, ...options }, context, abort, getAbortSignal);
+      } else {
+        return props.mock;
+      }
+    },
     // eslint-disable-next-line react-hooks/exhaustive-deps
-    [fetchData],
+    [fetchData, props.mock],
   );
 
   return {


### PR DESCRIPTION
# Why

This solves the issue #383 by skipping the network call in `refetch` function when `mock` is present in the props.
